### PR TITLE
perf(derep): deferred-division quals — store integer Phred sums, divide on demand (#23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "dada2-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "flate2",

--- a/comparison/benchmark/bench_pooled.py
+++ b/comparison/benchmark/bench_pooled.py
@@ -814,6 +814,8 @@ def main():
             print("\n  (note: each R split step reloads R + dada2 (~150-200 MB baseline);"
                   " small R steps floor there. Use --r-mode both for a fair wall.)")
     print(f"\nWrote {csv_path}")
+    print("  Compare runs (peak RSS / wall / cores) with compare_bench.py:")
+    print(f"    compare_bench.py --baseline a={csv_path.parent} --compare b=OTHER_OUTDIR")
 
 
 if __name__ == "__main__":

--- a/comparison/benchmark/compare_bench.py
+++ b/comparison/benchmark/compare_bench.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Compare bench_pooled.py metrics across runs (peak RSS, wall, cores, ...).
+
+bench_pooled.py writes a CSV for every run; this is the standalone diff tool for
+those CSVs, the metrics counterpart to compare_asvs.py (which diffs ASV sets).
+Run each configuration into its own --outdir, then compare the resulting CSVs
+baseline-vs-many. bench_pooled.py needs no changes.
+
+It reads the three CSV shapes bench_pooled.py emits, auto-detected by header
+(override with --kind):
+  * summary     : summary.csv      — per-step wall_s / cpu_s / cores / maxrss_kb,
+                  one block per stack (dada2-rs, R-split, R-single). Keyed by
+                  `step`; pick the stack with --stack (default dada2-rs).
+  * sweep_jobs  : sweep_jobs.csv   — --sample-jobs-sweep. Keyed by sample_jobs.
+  * sweep       : sweep.csv        — --thread-sweep. Keyed by threads.
+
+For each metric it prints one table: rows = steps (or sweep points), columns =
+runs, with a Δ% column per non-baseline run (vs the baseline). Lower-is-better
+metrics (wall_s, maxrss_kb) and higher-is-better (cores, speedup, efficiency)
+are both shown signed; read the sign with the metric in mind.
+
+Usage:
+  compare_bench.py --baseline LABEL=PATH --compare LABEL=PATH [--compare LABEL=PATH ...]
+
+  PATH is the CSV itself OR a directory containing it (summary.csv by default,
+  or the sweep CSV when --kind is given). LABEL is any short name (e.g. main,
+  branch, k5, j4).
+
+Examples:
+  # peak RSS + wall, main build vs the deferred-division branch (issue #23)
+  compare_bench.py --baseline main=bench_main --compare branch=bench_branch
+
+  # just peak RSS, three runs
+  compare_bench.py --metric maxrss_kb \\
+      --baseline main=bench_main/summary.csv \\
+      --compare b1=bench_b1/summary.csv --compare b2=bench_b2/summary.csv
+
+  # compare a sample-jobs sweep between two builds, machine-readable out
+  compare_bench.py --kind sweep_jobs --json diff.json \\
+      --baseline main=bench_main --compare branch=bench_branch
+
+Pure stdlib; no dependencies.
+"""
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+# Per CSV kind: the default filename, the key column (row identity), and the
+# metric columns to diff. Headers are matched to auto-detect the kind.
+KINDS = {
+    "summary": {
+        "file": "summary.csv",
+        "key": "step",
+        "metrics": ["wall_s", "cpu_s", "cores", "maxrss_kb"],
+        "header": ["stack", "step", "wall_s", "cpu_s", "cores", "maxrss_kb"],
+    },
+    "sweep_jobs": {
+        "file": "sweep_jobs.csv",
+        "key": "sample_jobs",
+        "metrics": ["wall_s", "cpu_s", "cores", "maxrss_kb", "speedup"],
+        "header": ["sample_jobs", "threads_per_job", "wall_s", "cpu_s",
+                   "cores", "maxrss_kb", "speedup"],
+    },
+    "sweep": {
+        "file": "sweep.csv",
+        "key": "threads",
+        "metrics": ["wall_s", "cpu_s", "cores", "speedup", "efficiency"],
+        "header": ["threads", "wall_s", "cpu_s", "cores", "speedup", "efficiency"],
+    },
+}
+
+# Metrics where smaller is better — used only to annotate the Δ direction.
+LOWER_IS_BETTER = {"wall_s", "cpu_s", "maxrss_kb"}
+
+
+def parse_run(spec, default_file):
+    """'label=path' -> (label, csv_path). path may be the CSV or its dir."""
+    if "=" not in spec:
+        sys.exit(f"--baseline/--compare expects LABEL=PATH, got: {spec!r}")
+    label, raw = spec.split("=", 1)
+    p = Path(raw)
+    if p.is_dir():
+        p = p / default_file
+    if not p.is_file():
+        sys.exit(f"{label}: not a file: {p}")
+    return label, p
+
+
+def detect_kind(path):
+    with open(path, newline="") as f:
+        header = next(csv.reader(f), [])
+    for kind, spec in KINDS.items():
+        if header == spec["header"]:
+            return kind
+    sys.exit(f"{path}: unrecognized CSV header {header}; pass --kind explicitly")
+
+
+def load(path, kind, stack):
+    """Return {key: {metric: float}} for the chosen kind (and stack, for summary).
+    Keys are kept as strings; order of first appearance is preserved by the caller
+    via the returned `order` list."""
+    spec = KINDS[kind]
+    rows, order = {}, []
+    with open(path, newline="") as f:
+        for r in csv.DictReader(f):
+            if kind == "summary" and r.get("stack") != stack:
+                continue
+            key = r[spec["key"]]
+            vals = {}
+            for m in spec["metrics"]:
+                v = r.get(m, "")
+                vals[m] = float(v) if v not in ("", None) else None
+            if key not in rows:
+                order.append(key)
+            rows[key] = vals
+    return rows, order
+
+
+def fmt(metric, v):
+    if v is None:
+        return "—"
+    if metric == "maxrss_kb":
+        mb = v / 1024
+        return f"{mb/1024:.2f} GB" if mb >= 1024 else f"{mb:.0f} MB"
+    if metric in ("wall_s", "cpu_s"):
+        return f"{v:.1f}s"
+    if metric in ("speedup",):
+        return f"{v:.2f}×"
+    if metric in ("efficiency",):
+        return f"{v*100:.0f}%"
+    return f"{v:.2f}"  # cores and anything else
+
+
+def pct(base, v):
+    if base in (None, 0) or v is None:
+        return None
+    return (v - base) / base * 100.0
+
+
+def print_table(metric, keys, runs, base_label):
+    """runs = list of (label, rows_dict); base_label is the baseline's label."""
+    arrow = "↓ better" if metric in LOWER_IS_BETTER else "↑ better"
+    print(f"\n### {metric}  ({arrow})")
+    # Column layout: key | base value | (value, Δ%) per compare run.
+    klen = max([len("step")] + [len(k) for k in keys])
+    head = f"{'':<{klen}}  {base_label:>12}"
+    for label, _ in runs[1:]:
+        head += f"  {label:>12}{'Δ%':>8}"
+    print(head)
+    base_rows = runs[0][1]
+    for k in keys:
+        base_v = base_rows.get(k, {}).get(metric)
+        line = f"{k:<{klen}}  {fmt(metric, base_v):>12}"
+        for _, rows in runs[1:]:
+            v = rows.get(k, {}).get(metric)
+            d = pct(base_v, v)
+            dstr = "—" if d is None else f"{d:+.1f}%"
+            line += f"  {fmt(metric, v):>12}{dstr:>8}"
+        print(line)
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--baseline", required=True, metavar="LABEL=PATH",
+                   help="reference run; deltas are computed against this one")
+    p.add_argument("--compare", action="append", default=[], metavar="LABEL=PATH",
+                   help="run to diff against the baseline (repeatable)")
+    p.add_argument("--kind", choices=list(KINDS), default=None,
+                   help="CSV shape (default: auto-detect from the baseline header)")
+    p.add_argument("--stack", default="dada2-rs",
+                   help="summary.csv only: which stack's rows to compare "
+                        "(dada2-rs, R-split, R-single). Default dada2-rs")
+    p.add_argument("--metric", action="append", default=None,
+                   help="metric(s) to show (repeatable); default: all for the kind")
+    p.add_argument("--json", metavar="OUT", help="also write the diff as JSON")
+    args = p.parse_args()
+
+    if not args.compare:
+        sys.exit("need at least one --compare LABEL=PATH")
+
+    # Resolve the baseline first so we can auto-detect the kind from its header.
+    kind = args.kind
+    base_label, base_path = parse_run(
+        args.baseline, KINDS[kind]["file"] if kind else "summary.csv")
+    if kind is None:
+        kind = detect_kind(base_path)
+        # Re-resolve in case the dir holds a non-default file for this kind.
+        base_label, base_path = parse_run(args.baseline, KINDS[kind]["file"])
+
+    spec = KINDS[kind]
+    metrics = args.metric or spec["metrics"]
+    for m in metrics:
+        if m not in spec["metrics"]:
+            sys.exit(f"metric {m!r} not in {kind} CSV (have: {', '.join(spec['metrics'])})")
+
+    runs, key_order = [], []
+    for label, path in [(base_label, base_path)] + [
+            parse_run(c, spec["file"]) for c in args.compare]:
+        rows, order = load(path, kind, args.stack)
+        if not rows:
+            where = f" (stack={args.stack})" if kind == "summary" else ""
+            sys.exit(f"{label}: no rows in {path}{where}")
+        runs.append((label, rows))
+        for k in order:
+            if k not in key_order:
+                key_order.append(k)
+
+    label_desc = ", ".join(l for l, _ in runs[1:])
+    print("=" * 64)
+    print(f"BENCH COMPARE — {kind}"
+          + (f" (stack={args.stack})" if kind == "summary" else "")
+          + f"\nbaseline: {base_label}   vs: {label_desc}")
+    print("=" * 64)
+    for m in metrics:
+        print_table(m, key_order, runs, base_label)
+
+    if args.json:
+        out = {"kind": kind, "stack": args.stack if kind == "summary" else None,
+               "baseline": base_label, "metrics": metrics,
+               "runs": {label: rows for label, rows in runs}}
+        Path(args.json).write_text(json.dumps(out, indent=2))
+        print(f"\nWrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -109,8 +109,32 @@ impl Raw {
     /// `seq` must already use the integer encoding (A=1, C=2, G=3, T=4).
     /// `qual` values are rounded to `u8`, matching the C++ implementation.
     pub fn new(seq: Vec<u8>, qual: Option<&[f64]>, reads: u32, prior: bool) -> Self {
+        let qual = qual.map(|q| q.iter().map(|&v| v.round() as u8).collect());
+        Self::with_qual(seq, qual, reads, prior)
+    }
+
+    /// Construct a Raw from integer per-position Phred *sums* (deferred division,
+    /// issue #23), recovering each stored u8 quality as `round(sum / reads)`.
+    ///
+    /// This builds the `u8` qual vector Raw owns directly from the sums — no
+    /// intermediate `Vec<f64>` mean. That intermediate, churned per-raw across
+    /// threads with variable sequence lengths, fragmented the glibc arena and
+    /// inflated peak RSS in the long-lived cached path; the scalar conversion
+    /// here avoids it entirely.
+    pub fn from_qual_sums(
+        seq: Vec<u8>,
+        qual_sums: Option<&[u32]>,
+        reads: u32,
+        prior: bool,
+    ) -> Self {
+        let c = reads as f64;
+        let qual = qual_sums.map(|s| s.iter().map(|&x| (x as f64 / c).round() as u8).collect());
+        Self::with_qual(seq, qual, reads, prior)
+    }
+
+    fn with_qual(seq: Vec<u8>, qual: Option<Vec<u8>>, reads: u32, prior: bool) -> Self {
         Raw {
-            qual: qual.map(|q| q.iter().map(|&v| v.round() as u8).collect()),
+            qual,
             seq,
             prior,
             kmer: None,

--- a/src/dada.rs
+++ b/src/dada.rs
@@ -118,17 +118,6 @@ pub struct RawInput {
     pub quals: Option<Vec<u32>>,
 }
 
-impl RawInput {
-    /// Recover the per-position mean Phred quality (`sum / abundance`) consumed
-    /// by the rest of the pipeline. `None` when no quals are stored.
-    pub fn mean_quals(&self) -> Option<Vec<f64>> {
-        self.quals.as_ref().map(|sums| {
-            let c = self.abundance as f64;
-            sums.iter().map(|&s| s as f64 / c).collect()
-        })
-    }
-}
-
 /// Per-cluster summary produced by `dada_uniques`.
 pub struct ClusterSummary {
     /// Integer-encoded representative (center) sequence.
@@ -301,8 +290,12 @@ pub fn dada_uniques_cached(
                 .enumerate()
                 .map(|(i, inp)| {
                     let seq: Vec<u8> = inp.seq.bytes().map(nt_encode).collect();
-                    let qual = if has_quals { inp.mean_quals() } else { None };
-                    let mut raw = Raw::new(seq, qual.as_deref(), inp.abundance, inp.prior);
+                    let qual = if has_quals {
+                        inp.quals.as_deref()
+                    } else {
+                        None
+                    };
+                    let mut raw = Raw::from_qual_sums(seq, qual, inp.abundance, inp.prior);
                     raw.index = i as u32;
                     raw
                 })

--- a/src/dada.rs
+++ b/src/dada.rs
@@ -119,29 +119,6 @@ pub struct RawInput {
 }
 
 impl RawInput {
-    /// Convert per-position mean Phred scores (the form every producer has on
-    /// hand) into the compact integer per-position sum stored in `quals`.
-    ///
-    /// `mean × abundance` recovers the exact integer sum the dereplicator
-    /// accumulated (the round-trip error of `s/c × c` is far below 0.5 for the
-    /// modest integer sums seen per unique), so this is lossless against the
-    /// prior f64-mean representation.
-    pub fn sums_from_means(means: &[f64], abundance: u32) -> Vec<u32> {
-        let c = abundance as f64;
-        means
-            .iter()
-            .map(|&m| {
-                let s = (m * c).round();
-                debug_assert!(
-                    (0.0..=u32::MAX as f64).contains(&s),
-                    "per-position Phred sum {s} overflows u32 (abundance {abundance}); \
-                     a single unique exceeds ~46M reads — widen to u64"
-                );
-                s as u32
-            })
-            .collect()
-    }
-
     /// Recover the per-position mean Phred quality (`sum / abundance`) consumed
     /// by the rest of the pipeline. `None` when no quals are stored.
     pub fn mean_quals(&self) -> Option<Vec<f64>> {

--- a/src/dada.rs
+++ b/src/dada.rs
@@ -99,9 +99,57 @@ pub struct RawInput {
     pub abundance: u32,
     /// When `true`, this sequence is presumed genuine regardless of p-value.
     pub prior: bool,
-    /// Per-position Phred quality scores. Must have the same length as `seq`
-    /// if provided. Supply `None` when quality data is unavailable.
-    pub quals: Option<Vec<f64>>,
+    /// Per-position *integer* Phred quality SUM over the reads in this unique
+    /// (deferred division, issue #23). Must have the same length as `seq` when
+    /// present; `None` when quality data is unavailable.
+    ///
+    /// We store the integer sum rather than the f64 mean for compactness: 4
+    /// bytes/position instead of 8, which roughly halves the dominant resident
+    /// field across all samples held in memory. The mean Phred the rest of the
+    /// pipeline consumes is recovered on demand via [`RawInput::mean_quals`] as
+    /// `sum / abundance`.
+    ///
+    /// This is bit-identical to storing the f64 mean: the sum is exact, and
+    /// `abundance` is the per-position read count for every covered position
+    /// because dereplication groups by exact full-sequence identity (all reads
+    /// in a unique are byte-identical → identical length → full coverage). If
+    /// approximate/length-collapsing dereplication is ever introduced, this
+    /// representation must carry per-position counts too.
+    pub quals: Option<Vec<u32>>,
+}
+
+impl RawInput {
+    /// Convert per-position mean Phred scores (the form every producer has on
+    /// hand) into the compact integer per-position sum stored in `quals`.
+    ///
+    /// `mean × abundance` recovers the exact integer sum the dereplicator
+    /// accumulated (the round-trip error of `s/c × c` is far below 0.5 for the
+    /// modest integer sums seen per unique), so this is lossless against the
+    /// prior f64-mean representation.
+    pub fn sums_from_means(means: &[f64], abundance: u32) -> Vec<u32> {
+        let c = abundance as f64;
+        means
+            .iter()
+            .map(|&m| {
+                let s = (m * c).round();
+                debug_assert!(
+                    (0.0..=u32::MAX as f64).contains(&s),
+                    "per-position Phred sum {s} overflows u32 (abundance {abundance}); \
+                     a single unique exceeds ~46M reads — widen to u64"
+                );
+                s as u32
+            })
+            .collect()
+    }
+
+    /// Recover the per-position mean Phred quality (`sum / abundance`) consumed
+    /// by the rest of the pipeline. `None` when no quals are stored.
+    pub fn mean_quals(&self) -> Option<Vec<f64>> {
+        self.quals.as_ref().map(|sums| {
+            let c = self.abundance as f64;
+            sums.iter().map(|&s| s as f64 / c).collect()
+        })
+    }
 }
 
 /// Per-cluster summary produced by `dada_uniques`.
@@ -276,12 +324,8 @@ pub fn dada_uniques_cached(
                 .enumerate()
                 .map(|(i, inp)| {
                     let seq: Vec<u8> = inp.seq.bytes().map(nt_encode).collect();
-                    let qual = if has_quals {
-                        inp.quals.as_deref()
-                    } else {
-                        None
-                    };
-                    let mut raw = Raw::new(seq, qual, inp.abundance, inp.prior);
+                    let qual = if has_quals { inp.mean_quals() } else { None };
+                    let mut raw = Raw::new(seq, qual.as_deref(), inp.abundance, inp.prior);
                     raw.index = i as u32;
                     raw
                 })

--- a/src/derep.rs
+++ b/src/derep.rs
@@ -10,13 +10,19 @@ use rayon::prelude::*;
 ///   by sequence (lexical, ascending). Matches R `derepFastq` ordering, where
 ///   `qtables2` builds uniques in lexical order and the final stable
 ///   `order(decreasing=TRUE)` leaves equal-count uniques in that lexical order.
-/// - `quals`:   mean Phred quality score per position for each unique sequence;
-///              `quals[i][j]` is the mean score at position `j` for unique `i`.
+/// - `quals`:   per-position *integer* Phred quality SUM over the reads in each
+///              unique (deferred division, issue #23); `quals[i][j]` is the
+///              summed score at position `j` for unique `i`. Consumers recover
+///              the mean on demand as `sum / count` (the unique's abundance) —
+///              the per-position count equals the unique's read count because
+///              dereplication groups by exact full-sequence identity, so every
+///              read covers every position. Storing the sum is bit-identical to
+///              the old f64 mean while using 4 bytes/position instead of 8.
 /// - `map`:     for each input read (in order), the index into `uniques` of the
 ///              unique sequence it maps to.
 pub struct Derep {
     pub uniques: Vec<(Vec<u8>, u64)>,
-    pub quals: Vec<Vec<f64>>,
+    pub quals: Vec<Vec<u32>>,
     pub map: Vec<usize>,
 }
 
@@ -114,16 +120,14 @@ impl PartialDerep {
     }
 
     fn into_derep(self) -> Derep {
-        let quals: Vec<Vec<f64>> = self
+        // Keep the integer per-position sum (deferred division, issue #23):
+        // consumers divide by the unique's count on demand. `qual_cnts` is
+        // redundant under exact-match dereplication (every read covers every
+        // position), so it equals the unique's count and we don't store it.
+        let quals: Vec<Vec<u32>> = self
             .qual_sums
             .iter()
-            .zip(self.qual_cnts.iter())
-            .map(|(sums, cnts)| {
-                sums.iter()
-                    .zip(cnts.iter())
-                    .map(|(&s, &c)| if c > 0 { s / c as f64 } else { 0.0 })
-                    .collect()
-            })
+            .map(|sums| sums.iter().map(|&s| s.round() as u32).collect())
             .collect();
 
         let n = self.seq_order.len();
@@ -150,11 +154,11 @@ impl PartialDerep {
         // entry from old → new index.
         let mut new_seq_order: Vec<Vec<u8>> = Vec::with_capacity(n);
         let mut new_counts: Vec<u64> = Vec::with_capacity(n);
-        let mut new_quals: Vec<Vec<f64>> = Vec::with_capacity(n);
+        let mut new_quals: Vec<Vec<u32>> = Vec::with_capacity(n);
         let mut old_to_new: Vec<usize> = vec![0; n];
         let seq_order_owned = self.seq_order;
         let mut seq_iter: Vec<Option<Vec<u8>>> = seq_order_owned.into_iter().map(Some).collect();
-        let mut quals_iter: Vec<Option<Vec<f64>>> = quals.into_iter().map(Some).collect();
+        let mut quals_iter: Vec<Option<Vec<u32>>> = quals.into_iter().map(Some).collect();
         for (new_idx, &old_idx) in order.iter().enumerate() {
             old_to_new[old_idx] = new_idx;
             new_seq_order.push(seq_iter[old_idx].take().unwrap());

--- a/src/learn_errors.rs
+++ b/src/learn_errors.rs
@@ -314,7 +314,7 @@ pub fn load_fastq_samples(
                 seq: String::from_utf8(seq).unwrap_or_default(),
                 abundance: count as u32,
                 prior: false,
-                quals: Some(RawInput::sums_from_means(&derep.quals[i], count as u32)),
+                quals: Some(derep.quals[i].clone()),
             })
             .collect();
 
@@ -354,7 +354,8 @@ pub fn load_fastq_samples(
 struct UniqueEntryJson {
     sequence: String,
     count: u64,
-    mean_quality: Vec<f64>,
+    /// Per-position integer Phred SUM; mean recovered as sum/count on demand.
+    qual_sum: Vec<u32>,
 }
 
 /// Top-level structure of a derep/sample JSON file.
@@ -386,7 +387,7 @@ pub fn load_derep_samples(paths: &[PathBuf]) -> io::Result<Vec<Vec<RawInput>>> {
                 .uniques
                 .into_iter()
                 .map(|u| RawInput {
-                    quals: Some(RawInput::sums_from_means(&u.mean_quality, u.count as u32)),
+                    quals: Some(u.qual_sum),
                     seq: u.sequence,
                     abundance: u.count as u32,
                     prior: false,

--- a/src/learn_errors.rs
+++ b/src/learn_errors.rs
@@ -412,9 +412,11 @@ fn detect_nq(all_inputs: &[Vec<RawInput>]) -> usize {
     let max_q = all_inputs
         .iter()
         .flat_map(|s| s.iter())
-        .filter_map(|r| r.mean_quals())
-        .flat_map(|qs| qs.into_iter())
-        .map(|q| q.round() as usize)
+        .filter_map(|r| r.quals.as_deref().map(|s| (s, r.abundance)))
+        .flat_map(|(s, ab)| {
+            s.iter()
+                .map(move |&x| (x as f64 / ab as f64).round() as usize)
+        })
         .max()
         .unwrap_or(40);
     max_q + 1
@@ -544,13 +546,14 @@ fn build_trans_mat(
                     Some(ci) => ci,
                     None => return (trans, buf),
                 };
-                let quals = match inp.mean_quals() {
-                    Some(q) => q,
+                let sums = match &inp.quals {
+                    Some(q) => q.as_slice(),
                     None => return (trans, buf),
                 };
+                let count = inp.abundance as f64;
 
                 let seq: Vec<u8> = inp.seq.bytes().map(nt_encode).collect();
-                let raw_query = Raw::new(seq, Some(&quals), inp.abundance, false);
+                let raw_query = Raw::from_qual_sums(seq, Some(sums), inp.abundance, false);
                 let raw_center = &center_raws[ci];
 
                 // Align center (ref = al0) against the raw (query = al1).
@@ -567,7 +570,7 @@ fn build_trans_mat(
                     let nt1 = al_qry[alpos];
                     let qry_is_nt = matches!(nt1, 1..=4);
                     if matches!(nt0, 1..=4) && qry_is_nt {
-                        let q = (quals[qpos].round() as usize).min(nq - 1);
+                        let q = ((sums[qpos] as f64 / count).round() as usize).min(nq - 1);
                         let row = (nt0 as usize - 1) * 4 + (nt1 as usize - 1);
                         trans[row * nq + q] = trans[row * nq + q].saturating_add(reads);
                     }

--- a/src/learn_errors.rs
+++ b/src/learn_errors.rs
@@ -314,7 +314,7 @@ pub fn load_fastq_samples(
                 seq: String::from_utf8(seq).unwrap_or_default(),
                 abundance: count as u32,
                 prior: false,
-                quals: Some(derep.quals[i].clone()),
+                quals: Some(RawInput::sums_from_means(&derep.quals[i], count as u32)),
             })
             .collect();
 
@@ -386,10 +386,10 @@ pub fn load_derep_samples(paths: &[PathBuf]) -> io::Result<Vec<Vec<RawInput>>> {
                 .uniques
                 .into_iter()
                 .map(|u| RawInput {
+                    quals: Some(RawInput::sums_from_means(&u.mean_quality, u.count as u32)),
                     seq: u.sequence,
                     abundance: u.count as u32,
                     prior: false,
-                    quals: Some(u.mean_quality),
                 })
                 .collect();
             // Defensive sort: derep JSONs produced by older versions (or by
@@ -411,8 +411,8 @@ fn detect_nq(all_inputs: &[Vec<RawInput>]) -> usize {
     let max_q = all_inputs
         .iter()
         .flat_map(|s| s.iter())
-        .filter_map(|r| r.quals.as_deref())
-        .flat_map(|qs| qs.iter().copied())
+        .filter_map(|r| r.mean_quals())
+        .flat_map(|qs| qs.into_iter())
         .map(|q| q.round() as usize)
         .max()
         .unwrap_or(40);
@@ -543,13 +543,13 @@ fn build_trans_mat(
                     Some(ci) => ci,
                     None => return (trans, buf),
                 };
-                let quals = match &inp.quals {
-                    Some(q) => q.as_slice(),
+                let quals = match inp.mean_quals() {
+                    Some(q) => q,
                     None => return (trans, buf),
                 };
 
                 let seq: Vec<u8> = inp.seq.bytes().map(nt_encode).collect();
-                let raw_query = Raw::new(seq, Some(quals), inp.abundance, false);
+                let raw_query = Raw::new(seq, Some(&quals), inp.abundance, false);
                 let raw_center = &center_raws[ci];
 
                 // Align center (ref = al0) against the raw (query = al1).

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,7 +283,8 @@ fn main() -> io::Result<()> {
             struct UniqueEntry<'a> {
                 sequence: &'a str,
                 count: u64,
-                mean_quality: &'a [f64],
+                /// Per-position integer Phred SUM; consumers divide by `count` on demand.
+                qual_sum: &'a [u32],
             }
 
             #[derive(Serialize)]
@@ -306,7 +307,7 @@ fn main() -> io::Result<()> {
                 uniq_entries.push(UniqueEntry {
                     sequence,
                     count: *count,
-                    mean_quality: &derep.quals[i],
+                    qual_sum: &derep.quals[i],
                 });
             }
 
@@ -489,7 +490,7 @@ fn main() -> io::Result<()> {
                                 seq: sequence,
                                 abundance: count as u32,
                                 prior: false,
-                                quals: Some(dada::RawInput::sums_from_means(&quals, count as u32)),
+                                quals: Some(quals),
                             }
                         })
                         .collect();
@@ -553,7 +554,7 @@ fn main() -> io::Result<()> {
                         seq: sequence,
                         abundance: count as u32,
                         prior: false,
-                        quals: Some(dada::RawInput::sums_from_means(&quals, count as u32)),
+                        quals: Some(quals),
                     }
                 })
                 .collect();
@@ -946,8 +947,10 @@ fn main() -> io::Result<()> {
                     let mu = match seq_to_merged.get(seq) {
                         Some(&i) => {
                             merged_total[i] += count_u32;
+                            // `qual` is already this unique's per-position Phred
+                            // sum; accumulate sums across samples.
                             for (p, &q) in qual.iter().enumerate() {
-                                merged_qual_sum[i][p] += q * count_u32 as f64;
+                                merged_qual_sum[i][p] += q as f64;
                             }
                             i
                         }
@@ -955,8 +958,7 @@ fn main() -> io::Result<()> {
                             let i = merged_seqs.len();
                             seq_to_merged.insert(seq.clone(), i);
                             merged_seqs.push(seq.clone());
-                            merged_qual_sum
-                                .push(qual.iter().map(|&q| q * count_u32 as f64).collect());
+                            merged_qual_sum.push(qual.iter().map(|&q| q as f64).collect());
                             merged_total.push(count_u32);
                             i
                         }
@@ -979,13 +981,15 @@ fn main() -> io::Result<()> {
             // ---- Build merged RawInput list ----
             let mut raw_inputs: Vec<dada::RawInput> = (0..n_merged)
                 .map(|i| {
-                    let total = merged_total[i] as f64;
-                    let mean_qual: Vec<f64> =
-                        merged_qual_sum[i].iter().map(|&s| s / total).collect();
                     let sequence: String = String::from_utf8(merged_seqs[i].clone())
                         .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
                     dada::RawInput {
-                        quals: Some(dada::RawInput::sums_from_means(&mean_qual, merged_total[i])),
+                        quals: Some(
+                            merged_qual_sum[i]
+                                .iter()
+                                .map(|&s| s.round() as u32)
+                                .collect(),
+                        ),
                         seq: sequence,
                         abundance: merged_total[i],
                         prior: false,
@@ -2233,7 +2237,8 @@ fn main() -> io::Result<()> {
             struct UniqueEntry<'a> {
                 sequence: &'a str,
                 count: u64,
-                mean_quality: &'a [f64],
+                /// Per-position integer Phred SUM; consumers divide by `count` on demand.
+                qual_sum: &'a [u32],
             }
             #[derive(Serialize)]
             struct DerepOutput<'a> {
@@ -2304,7 +2309,7 @@ fn main() -> io::Result<()> {
                     uniq_entries.push(UniqueEntry {
                         sequence,
                         count: *count,
-                        mean_quality: &derep.quals[i],
+                        qual_sum: &derep.quals[i],
                     });
                 }
                 let sample_out = DerepOutput {
@@ -3710,7 +3715,7 @@ fn load_sample_raws(
                 seq: sequence,
                 abundance: count as u32,
                 prior: false,
-                quals: Some(dada::RawInput::sums_from_means(&quals, count as u32)),
+                quals: Some(quals),
             }
         })
         .collect();
@@ -3884,7 +3889,8 @@ fn load_derep_for_dada(
         struct UniqueEntryJson {
             sequence: String,
             count: u64,
-            mean_quality: Vec<f64>,
+            /// Per-position integer Phred SUM; mean recovered as sum/count on demand.
+            qual_sum: Vec<u32>,
         }
         #[derive(serde::Deserialize)]
         struct SampleJson {
@@ -3903,21 +3909,21 @@ fn load_derep_for_dada(
             entries.sort_by_key(|a| std::cmp::Reverse(a.count));
         }
         let mut uniques: Vec<(Vec<u8>, u64)> = Vec::with_capacity(entries.len());
-        let mut quals: Vec<Vec<f64>> = Vec::with_capacity(entries.len());
+        let mut quals: Vec<Vec<u32>> = Vec::with_capacity(entries.len());
         for u in entries {
-            if !u.mean_quality.is_empty() && u.mean_quality.len() != u.sequence.len() {
+            if !u.qual_sum.is_empty() && u.qual_sum.len() != u.sequence.len() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!(
-                        "{}: mean_quality length {} != sequence length {}",
+                        "{}: qual_sum length {} != sequence length {}",
                         path.display(),
-                        u.mean_quality.len(),
+                        u.qual_sum.len(),
                         u.sequence.len(),
                     ),
                 ));
             }
             uniques.push((u.sequence.into_bytes(), u.count));
-            quals.push(u.mean_quality);
+            quals.push(u.qual_sum);
         }
         Ok((
             derep::Derep {

--- a/src/main.rs
+++ b/src/main.rs
@@ -489,7 +489,7 @@ fn main() -> io::Result<()> {
                                 seq: sequence,
                                 abundance: count as u32,
                                 prior: false,
-                                quals: Some(quals),
+                                quals: Some(dada::RawInput::sums_from_means(&quals, count as u32)),
                             }
                         })
                         .collect();
@@ -553,7 +553,7 @@ fn main() -> io::Result<()> {
                         seq: sequence,
                         abundance: count as u32,
                         prior: false,
-                        quals: Some(quals),
+                        quals: Some(dada::RawInput::sums_from_means(&quals, count as u32)),
                     }
                 })
                 .collect();
@@ -985,10 +985,10 @@ fn main() -> io::Result<()> {
                     let sequence: String = String::from_utf8(merged_seqs[i].clone())
                         .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
                     dada::RawInput {
+                        quals: Some(dada::RawInput::sums_from_means(&mean_qual, merged_total[i])),
                         seq: sequence,
                         abundance: merged_total[i],
                         prior: false,
-                        quals: Some(mean_qual),
                     }
                 })
                 .collect();
@@ -3710,7 +3710,7 @@ fn load_sample_raws(
                 seq: sequence,
                 abundance: count as u32,
                 prior: false,
-                quals: Some(quals),
+                quals: Some(dada::RawInput::sums_from_means(&quals, count as u32)),
             }
         })
         .collect();


### PR DESCRIPTION
## Summary

Implements the **deferred-division** representation from #23: store the
per-position **integer Phred sum** (`u32`) per unique instead of the f64 mean,
and recover `mean = sum / count` on demand at the point of use. `count` is the
unique's abundance — exact under exact-match dereplication, where every read in
a unique covers every position.

This is **bit-identical** to the prior f64-mean path (the kernel rounds quals to
`u8` anyway; the sum is exact; division — not multiply-by-inverse — preserves
`round()` boundaries) and **strictly smaller resident** (4 bytes/position vs 8).

### Changes
- `RawInput.quals`: `Option<Vec<f64>>` → `Option<Vec<u32>>` (integer sums).
- `Derep.quals` carries integer sums end-to-end; the **derep/sample JSON** field
  changes `mean_quality: [f64]` → `qual_sum: [u32]` (clean break, smaller + exact
  on disk). Mean is recovered on demand, never retained.
- `Raw::from_qual_sums` builds Raw's `u8` qual directly from the sums (no
  transient `Vec<f64>`); the two other consumers compute the rounded per-position
  Q inline.
- New `comparison/benchmark/compare_bench.py` — standalone comparator that diffs
  the CSVs `bench_pooled.py` already emits (peak RSS / wall / cores) across runs.

## Benchmark (validated)

Clean single-node interleaved run (PacBio, k=5, `--pool pseudo --cache-samples`,
24 threads), `main` vs this branch:

| metric | main | deferred | Δ |
|---|---:|---:|---:|
| **peak RSS (dada)** | 13.51 GB | **8.82 GB** | **−34.7%** |
| peak RSS (learn) | 1.67 GB | 1.52 GB | ~−10% |
| wall / cpu / cores | — | — | flat (±0.4%) |

Byte-identical output; full suite green; `dada_from_fastq_matches_dada_from_derep_json`
unchanged.

## Note on earlier benchmark anomalies (resolved)
Two scary intermediate numbers were **benchmark confounds**, not code:
- a "+31% cached regression" was a **label swap** (the heavier build was `main`);
- a "+19% wall" was **concurrent-job contention** on the shared node (wall+cpu both
  up, cores flat). `maxrss` is per-process so memory was always trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)