### PR TITLE
bench: add R derep-input mode (filenames vs preloaded objects)

### DIFF
--- a/comparison/benchmark/bench_pooled.py
+++ b/comparison/benchmark/bench_pooled.py
@@ -485,7 +485,8 @@ def r_common_args(args, statedir):
     a = [f"platform={args.platform}", f"statedir={statedir}",
          f"threads={args.threads}", f"nbases={args.nbases}", f"input={args.input}",
          f"max_ee={mee}", f"trunc_q={args.trunc_q}", f"max_n={args.max_n}",
-         f"pool={args.pool}", f"pseudo_prevalence={args.pseudo_prevalence}"]
+         f"pool={args.pool}", f"pseudo_prevalence={args.pseudo_prevalence}",
+         f"r_derep_mode={args.r_derep_mode}"]
     if args.pseudo_min_abundance is not None:
         a.append(f"pseudo_min_abundance={args.pseudo_min_abundance}")
     if args.platform == "illumina":
@@ -536,7 +537,8 @@ def run_r_single(args, outdir):
     a = [f"platform={args.platform}", f"input={args.input}", f"outdir={rdir}",
          f"threads={args.threads}", f"nbases={args.nbases}",
          f"max_ee={mee}", f"trunc_q={args.trunc_q}", f"max_n={args.max_n}",
-         f"pool={args.pool}", f"pseudo_prevalence={args.pseudo_prevalence}"]
+         f"pool={args.pool}", f"pseudo_prevalence={args.pseudo_prevalence}",
+         f"r_derep_mode={args.r_derep_mode}"]
     if args.pseudo_min_abundance is not None:
         a.append(f"pseudo_min_abundance={args.pseudo_min_abundance}")
     if args.platform == "illumina":
@@ -666,6 +668,14 @@ def main():
                         "one process for the whole pipeline (fair end-to-end wall + one "
                         "overall RSS, per-step wall from system.time, no per-step RSS); "
                         "'both' (default) runs each and reports side by side")
+    p.add_argument("--r-derep-mode", choices=["filenames", "objects"], default="filenames",
+                   help="how R's dada() receives its input. 'filenames' (default): pass "
+                        "file paths so dada() dereplicates on the fly, one sample resident "
+                        "at a time (streamed; ~ dada2-rs streaming). 'objects': derepFastq() "
+                        "all samples up front and pass the list so dada() holds ALL derep "
+                        "objects resident (~ dada2-rs --cache-samples). Use 'objects' for a "
+                        "like-for-like preloaded-RSS comparison against --cache-samples; the "
+                        "derepFastq cost is counted inside the dada step.")
     p.add_argument("--no-run-rust", action="store_true", help="skip the dada2-rs pipeline")
     p.add_argument("--verbose", action="store_true",
                    help="pass --verbose to each dada2-rs step (filter/remove-primers/"
@@ -753,7 +763,8 @@ def main():
     mode = {"true": "pooled", "false": "per-sample", "pseudo": "pseudo"}[args.pool]
     if args.pool == "pseudo":
         mode += " cached" if args.cache_samples else " streaming"
-    print(f"BENCHMARK SUMMARY — {args.platform}, {mode} denoise, {args.threads} thread(s)")
+    rmode = f", R derep={args.r_derep_mode}" if args.run_r else ""
+    print(f"BENCHMARK SUMMARY — {args.platform}, {mode} denoise, {args.threads} thread(s){rmode}")
     print("=" * 56)
     print(f"  cores = CPU/wall (effective cores; ideal ≈ {args.threads} for an "
           "in-process step, ≈ min(#samples, threads) for fanned steps)")

--- a/comparison/benchmark/bench_step.R
+++ b/comparison/benchmark/bench_step.R
@@ -58,6 +58,20 @@ pseudo_prev <- getn("pseudo_prevalence", 2)
 pseudo_abund <- getn("pseudo_min_abundance", NA)
 pseudo_abund <- if (is.na(pseudo_abund)) Inf else pseudo_abund   # R PSEUDO_ABUNDANCE default Inf
 
+# R derep input mode (mirrors how getDerep() behaves on the dada() input):
+#   "filenames" (default) -> pass file paths; dada() dereplicates on the fly,
+#       holding ONE sample resident at a time (streamed). ~ dada2-rs streaming.
+#   "objects"             -> derepFastq() all filts up front and pass the LIST;
+#       dada() then holds ALL derep objects resident. ~ dada2-rs --cache-samples.
+# The derepFastq() cost stays inside the timed dada() call so its wall AND peak
+# RSS are counted, matching dada2-rs where the cached load happens in the dada
+# step. (R's derep$quals is a matrix of doubles, so mode "objects" is the like-
+# for-like resident comparison against our u32 sums.)
+r_derep_mode <- getv("r_derep_mode", "filenames")
+dada_input <- function(filts) {
+  if (identical(r_derep_mode, "objects")) derepFastq(filts) else filts
+}
+
 sp <- function(name) file.path(statedir, name)   # state path helper
 
 timed <- function(name, expr) {
@@ -108,14 +122,14 @@ if (platform == "illumina") {
 
   } else if (step == "dada_fwd") {
     m <- readRDS(sp("manifest.rds")); errF <- readRDS(sp("errF.rds"))
-    ddF <- timed("dada_fwd", dada(m$filtFs, err = errF, pool = pool_flag,
+    ddF <- timed("dada_fwd", dada(dada_input(m$filtFs), err = errF, pool = pool_flag,
                                   PSEUDO_PREVALENCE = pseudo_prev, PSEUDO_ABUNDANCE = pseudo_abund,
                                   multithread = multithread))
     saveRDS(ddF, sp("ddF.rds"))
 
   } else if (step == "dada_rev") {
     m <- readRDS(sp("manifest.rds")); errR <- readRDS(sp("errR.rds"))
-    ddR <- timed("dada_rev", dada(m$filtRs, err = errR, pool = pool_flag,
+    ddR <- timed("dada_rev", dada(dada_input(m$filtRs), err = errR, pool = pool_flag,
                                   PSEUDO_PREVALENCE = pseudo_prev, PSEUDO_ABUNDANCE = pseudo_abund,
                                   multithread = multithread))
     saveRDS(ddR, sp("ddR.rds"))
@@ -187,7 +201,7 @@ if (platform == "illumina") {
 
   } else if (step == "dada") {
     m <- readRDS(sp("manifest.rds")); err <- readRDS(sp("err.rds"))
-    dd <- timed("dada", dada(m$filts, err = err, pool = pool_flag, BAND_SIZE = band,
+    dd <- timed("dada", dada(dada_input(m$filts), err = err, pool = pool_flag, BAND_SIZE = band,
                              HOMOPOLYMER_GAP_PENALTY = homo,
                              PSEUDO_PREVALENCE = pseudo_prev, PSEUDO_ABUNDANCE = pseudo_abund,
                              multithread = multithread))

--- a/comparison/benchmark/run_dada2_pooled.R
+++ b/comparison/benchmark/run_dada2_pooled.R
@@ -61,6 +61,15 @@ pseudo_prev  <- getn("pseudo_prevalence", 2)
 pseudo_abund <- getn("pseudo_min_abundance", NA)
 pseudo_abund <- if (is.na(pseudo_abund)) Inf else pseudo_abund   # R PSEUDO_ABUNDANCE default Inf
 
+# R derep input mode: "filenames" (default) -> dada() dereps on the fly (one
+# sample resident; streamed). "objects" -> derepFastq() up front and pass the
+# list so dada() holds ALL derep objects resident (~ dada2-rs --cache-samples).
+# See bench_step.R for the full rationale.
+r_derep_mode <- getv("r_derep_mode", "filenames")
+dada_input <- function(filts) {
+  if (identical(r_derep_mode, "objects")) derepFastq(filts) else filts
+}
+
 filt_dir <- file.path(outdir, "filtered_R")
 dir.create(filt_dir, showWarnings = FALSE, recursive = TRUE)
 
@@ -104,10 +113,10 @@ if (platform == "illumina") {
   errF <- timed("learn_fwd", learnErrors(filtFs, nbases = nbases, multithread = multithread))
   errR <- timed("learn_rev", learnErrors(filtRs, nbases = nbases, multithread = multithread))
 
-  ddF <- timed("dada_fwd", dada(filtFs, err = errF, pool = pool_flag,
+  ddF <- timed("dada_fwd", dada(dada_input(filtFs), err = errF, pool = pool_flag,
                                 PSEUDO_PREVALENCE = pseudo_prev, PSEUDO_ABUNDANCE = pseudo_abund,
                                 multithread = multithread))
-  ddR <- timed("dada_rev", dada(filtRs, err = errR, pool = pool_flag,
+  ddR <- timed("dada_rev", dada(dada_input(filtRs), err = errR, pool = pool_flag,
                                 PSEUDO_PREVALENCE = pseudo_prev, PSEUDO_ABUNDANCE = pseudo_abund,
                                 multithread = multithread))
 
@@ -153,7 +162,7 @@ if (platform == "illumina") {
                                     BAND_SIZE = band, HOMOPOLYMER_GAP_PENALTY = homo,
                                     multithread = multithread))
 
-  dd <- timed("dada", dada(filts, err = err, pool = pool_flag, BAND_SIZE = band,
+  dd <- timed("dada", dada(dada_input(filts), err = err, pool = pool_flag, BAND_SIZE = band,
                            HOMOPOLYMER_GAP_PENALTY = homo,
                            PSEUDO_PREVALENCE = pseudo_prev, PSEUDO_ABUNDANCE = pseudo_abund,
                            multithread = multithread))


### PR DESCRIPTION
## Summary

Adds a `--r-derep-mode {filenames,objects}` switch to the benchmark harness so
the R side can be run in either of the two ways R's `dada()` actually processes
input (`getDerep`, dada.R:267):

- **`filenames`** (default, unchanged behavior) — pass file paths; `dada()`
  dereplicates on the fly, holding one sample resident at a time. ≈ dada2-rs
  **streaming**.
- **`objects`** — `derepFastq()` all samples up front and pass the list; `dada()`
  holds **all** derep objects resident. ≈ dada2-rs **`--cache-samples`**.

The `derepFastq()` cost stays inside the timed `dada` step, so its wall time and
peak RSS are counted — matching dada2-rs, where the cached load happens inside
the dada step.

## Why

R's `derep$quals` is a matrix of **doubles**, so mode `objects` is the
like-for-like resident comparison against dada2-rs's `u32` Phred sums (#23) in
the preloaded path, e.g.:

```
bench_pooled.py pacbio $DATA --pool pseudo --cache-samples --sample-jobs 1 \
    --run-r --r-derep-mode objects --kmer-size 5 --threads 24 \
    --dada2rs target/release-native/dada2-rs
```

Mode `filenames` remains the right comparison for dada2-rs streaming.

## Files
- `bench_step.R`, `run_dada2_pooled.R` — `r_derep_mode` arg + `dada_input()` helper; the three `dada()` calls take `dada_input(...)`.
- `bench_pooled.py` — `--r-derep-mode` flag, threaded into both R arg builders, shown in the summary header.

Default unchanged, so existing runs are unaffected. Benchmark tooling only; no library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)