### PR TITLE
feat(io): default derep/sample JSON to compact + extension-driven gzip (#1)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,8 +57,8 @@ pub enum Commands {
     /// Dereplicate sequences from a FASTQ file
     ///
     /// Produces the equivalent of the R dada2 `derep` class: a set of unique
-    /// sequences with read counts, per-unique mean quality profiles, and a
-    /// read-to-unique mapping.
+    /// sequences with read counts, per-unique integer Phred quality sums
+    /// (`qual_sum`; mean = sum / count), and a read-to-unique mapping.
     #[command(display_order = 4)]
     Derep {
         /// Input FASTQ file (uncompressed or gzipped)
@@ -83,13 +83,15 @@ pub enum Commands {
         #[arg(long)]
         show_map: bool,
 
-        /// Write JSON output to this file instead of stdout
+        /// Write JSON output to this file instead of stdout. When the path ends
+        /// in `.gz` the output is gzip-compressed (read back transparently).
         #[arg(long, short = 'o')]
         output: Option<PathBuf>,
 
-        /// Output compact (minified) JSON instead of pretty-printed
+        /// Pretty-print the JSON. Default output is compact (minified), which is
+        /// ~34% smaller on disk; pass this for human-readable output.
         #[arg(long)]
-        compact: bool,
+        pretty: bool,
 
         /// Print progress information to stderr
         #[arg(long)]
@@ -1304,9 +1306,15 @@ pub enum Commands {
         #[arg(long, default_value_t = 1)]
         threads: usize,
 
-        /// Output compact (minified) JSON instead of pretty-printed
+        /// Pretty-print the JSON. Default output is compact (minified), which is
+        /// ~34% smaller on disk; pass this for human-readable output.
         #[arg(long)]
-        compact: bool,
+        pretty: bool,
+
+        /// Gzip each per-sample JSON (writes `{sample}.json.gz`). Read back
+        /// transparently by downstream subcommands.
+        #[arg(long)]
+        gzip: bool,
 
         /// Print progress to stderr
         #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn main() -> io::Result<()> {
             threads,
             output,
             show_map,
-            compact,
+            pretty,
             verbose,
         } => {
             let pool = rayon::ThreadPoolBuilder::new()
@@ -322,15 +322,15 @@ fn main() -> io::Result<()> {
             };
 
             let tagged = Tagged::new("derep", derep_out);
-            let json = if compact {
-                serde_json::to_string(&tagged)
-            } else {
+            let json = if pretty {
                 serde_json::to_string_pretty(&tagged)
+            } else {
+                serde_json::to_string(&tagged)
             }
             .map_err(io::Error::other)?;
 
             match output {
-                Some(path) => std::fs::write(&path, &json)?,
+                Some(path) => misc::write_maybe_gz(&path, json.as_bytes())?,
                 None => println!("{json}"),
             }
         }
@@ -2214,7 +2214,8 @@ fn main() -> io::Result<()> {
             seed,
             phred_offset,
             threads,
-            compact,
+            pretty,
+            gzip,
             verbose,
         } => {
             std::fs::create_dir_all(&output_dir)?;
@@ -2302,7 +2303,8 @@ fn main() -> io::Result<()> {
                         s1.to_string_lossy().into_owned()
                     }
                 };
-                let out_path = output_dir.join(format!("{stem}.json"));
+                let ext = if gzip { "json.gz" } else { "json" };
+                let out_path = output_dir.join(format!("{stem}.{ext}"));
 
                 let mut uniq_entries = Vec::with_capacity(derep.uniques.len());
                 for (i, (seq, count)) in derep.uniques.iter().enumerate() {
@@ -2324,14 +2326,14 @@ fn main() -> io::Result<()> {
 
                 let unique_count = sample_out.unique_sequences;
                 let tagged = Tagged::new("sample", sample_out);
-                let json = if compact {
-                    serde_json::to_string(&tagged)
-                } else {
+                let json = if pretty {
                     serde_json::to_string_pretty(&tagged)
+                } else {
+                    serde_json::to_string(&tagged)
                 }
                 .map_err(io::Error::other)?;
 
-                std::fs::write(&out_path, &json)?;
+                misc::write_maybe_gz(&out_path, json.as_bytes())?;
                 output_files.push(out_path.display().to_string());
                 total_bases += file_bases;
                 total_reads += file_reads;
@@ -2364,10 +2366,10 @@ fn main() -> io::Result<()> {
                 output_files,
             };
             let tagged = Tagged::new("sample", summary);
-            let summary_json = if compact {
-                serde_json::to_string(&tagged)
-            } else {
+            let summary_json = if pretty {
                 serde_json::to_string_pretty(&tagged)
+            } else {
+                serde_json::to_string(&tagged)
             }
             .map_err(io::Error::other)?;
             println!("{summary_json}");

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,10 +1,39 @@
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Read};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::path::Path;
 
+use flate2::Compression;
 use flate2::read::MultiGzDecoder;
+use flate2::write::GzEncoder;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+
+/// Write `bytes` to `path`, gzip-compressing when the path ends in `.gz`
+/// (otherwise written verbatim). Parent directories are created as needed.
+///
+/// Plain gzip (not bgzf): these JSON artifacts are read back whole via
+/// [`read_all_maybe_gz`], so bgzf's blocked/seekable layout and multithreaded
+/// compression buy nothing here — plain gzip is smaller and simpler, and the
+/// output is read transparently by the existing `.gz`-sniffing reader.
+pub fn write_maybe_gz(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = File::create(path)?;
+    let is_gz = path.extension().and_then(|e| e.to_str()) == Some("gz");
+    if is_gz {
+        let mut w = GzEncoder::new(file, Compression::default());
+        w.write_all(bytes)?;
+        w.finish()?;
+    } else {
+        let mut w = BufWriter::new(file);
+        w.write_all(bytes)?;
+        w.flush()?;
+    }
+    Ok(())
+}
 
 /// Returns `true` when `path` is the stdin sentinel `-`.
 fn is_stdin(path: &Path) -> bool {


### PR DESCRIPTION
## Summary

Makes the derep/sample JSON storage path lean by default, per the disk-size
measurement in #1:

| | raw | gzip |
|---|---:|---:|
| compact vs pretty | **~34% smaller** | — |
| qual_sum compact, gzipped | — | ~10–11% over uncompressed-field |

- **Compact by default** for `derep` and `sample`; `--pretty` opts back into
  human-readable output.
- **`derep`**: gzip when `-o` ends in `.gz` (extension-driven, predictable —
  bytes match the extension). Read back transparently by the existing
  `.gz`-sniffing reader (`read_all_maybe_gz`).
- **`sample`** (batch, auto-names files in `--output-dir`): `--gzip` writes
  `{sample}.json.gz`.
- New `misc::write_maybe_gz(path, bytes)` — plain gzip (flate2) when the path
  ends in `.gz`, else verbatim.

### Why plain gzip, not bgzf
The project uses bgzf for FASTQ output (parallel + seekable). These JSON files
are read **whole** via `read_all_maybe_gz`, so bgzf's blocked/seekable layout
and multithreaded compression buy nothing — plain gzip is smaller and simpler,
and the output is still valid gzip.

## Scope
`derep` + `sample` only — the storage artifacts #1 measured. The other JSON
outputs (`dada`/`merge-pairs`/`make-sequence-table`) still default to pretty with
opt-in `--compact`; flipping them is a trivial follow-up using the same helper.

## CLI change
`--compact` is replaced by `--pretty` on `derep`/`sample` (compact is now the
default). Pre-1.0, and the storage artifacts are the intended consumers.

## Verification
- Compact default: 929 KB vs 2.98 MB pretty (sam1F); `--pretty` restores readable.
- `derep -o x.json.gz` → valid gzip (159 KB), round-trips through `dada`.
- `sample --gzip` → `{sample}.json.gz`.
- Full suite green (42 unit + 12 integration; parity test confirms compact derep
  JSON round-trips); clippy + fmt clean.

Closes the compact+gzip item of #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)