### PR TITLE
perf(mem): drop resident 16-bit k-mer vector from Raw, recompute on overflow (#32)

### DIFF
--- a/src/containers.rs
+++ b/src/containers.rs
@@ -81,9 +81,12 @@ pub struct Raw {
     pub qual: Option<Vec<u8>>,
     /// Prior reasons to expect this sequence to be genuine.
     pub prior: bool,
-    /// 16-bit k-mer frequency vector; populated by kmers module.
-    pub kmer: Option<Vec<u16>>,
-    /// 8-bit compressed k-mer frequency vector; populated by kmers module.
+    /// 8-bit compressed k-mer frequency vector; populated by kmers module. This
+    /// is the resident k-mer screen. The exact 16-bit frequency vector is NOT
+    /// stored (issue #32: it dominated pooled RSS at k7, ~4^k × 2 bytes/unique,
+    /// and is only needed when `kmer_dist8` overflows — a k-mer occurring ≥255×
+    /// in both sequences, essentially never for amplicons); on that path it is
+    /// recomputed from `seq` in `raw_align_with_buf`.
     pub kmer8: Option<Vec<u8>>,
     /// K-mers in the order they appear along the sequence; populated by kmers module.
     pub kord: Option<Vec<u16>>,
@@ -137,7 +140,6 @@ impl Raw {
             qual,
             seq,
             prior,
-            kmer: None,
             kmer8: None,
             kord: None,
             reads,
@@ -156,7 +158,7 @@ impl Raw {
 
     /// Reset per-iteration mutable state so this Raw can be fed back into a
     /// fresh DADA run without re-encoding the sequence or recomputing k-mer
-    /// vectors. Leaves `seq`, `qual`, `kmer*`, `kord`, `reads`, `prior`
+    /// vectors. Leaves `seq`, `qual`, `kmer8`, `kord`, `reads`, `prior`
     /// intact — those are fixed for the life of the input. `index` is
     /// reassigned by `B::new`.
     pub fn reset_for_iteration(&mut self) {

--- a/src/kmers.rs
+++ b/src/kmers.rs
@@ -96,9 +96,12 @@ pub fn assign_kmer_order(seq: &[u8], k: usize) -> Vec<u16> {
         .collect()
 }
 
-/// Populate all k-mer fields (`kmer`, `kmer8`, `kord`) on a `Raw`.
+/// Populate the resident k-mer screen fields (`kmer8`, `kord`) on a `Raw`.
+///
+/// The exact 16-bit frequency vector is intentionally NOT stored (issue #32):
+/// it dominated pooled RSS at k7 and is only consulted on the `kmer_dist8`
+/// overflow fallback, where it is recomputed from `seq` via [`assign_kmer`].
 pub fn raw_assign_kmers(raw: &mut Raw, k: usize) {
-    raw.kmer = Some(assign_kmer(&raw.seq, k));
     raw.kmer8 = Some(assign_kmer8(&raw.seq, k));
     raw.kord = Some(assign_kmer_order(&raw.seq, k));
 }

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -12,7 +12,7 @@
 //! Traceback pointer values: `1` = diagonal, `2` = left (gap in s1), `3` = up (gap in s2).
 
 use crate::containers::{Raw, Sub};
-use crate::kmers::{kmer_dist, kmer_dist8, kord_dist};
+use crate::kmers::{assign_kmer, kmer_dist, kmer_dist8, kord_dist};
 
 /// Sentinel used in `Sub::map` to indicate that a reference position aligns
 /// to a gap in the query.  Matches C++ `GAP_GLYPH = 9999`.
@@ -1126,19 +1126,21 @@ pub fn raw_align_with_buf(
             (Some(k1), Some(k2)) => {
                 let d8 = kmer_dist8(k1, raw1.len(), k2, raw2.len(), k);
                 if d8 < 0.0 {
-                    // Overflow: use 16-bit vectors.
-                    match (&raw1.kmer, &raw2.kmer) {
-                        (Some(k1), Some(k2)) => kmer_dist(k1, raw1.len(), k2, raw2.len(), k),
-                        _ => 0.0,
-                    }
+                    // Overflow (a k-mer occurs ≥255× in both seqs): fall back to
+                    // the exact 16-bit distance. The u16 vectors are not kept
+                    // resident (issue #32), so recompute them from sequence here
+                    // — this path is essentially never hit for amplicon data.
+                    let v1 = assign_kmer(&raw1.seq, k);
+                    let v2 = assign_kmer(&raw2.seq, k);
+                    kmer_dist(&v1, raw1.len(), &v2, raw2.len(), k)
                 } else {
                     d8
                 }
             }
-            _ => match (&raw1.kmer, &raw2.kmer) {
-                (Some(k1), Some(k2)) => kmer_dist(k1, raw1.len(), k2, raw2.len(), k),
-                _ => 0.0,
-            },
+            // No 8-bit vectors built (e.g. cluster-center raws): no k-mer screen,
+            // exactly as before — previously both kmer8 and the u16 kmer were
+            // absent together, yielding kdist = 0.0.
+            _ => 0.0,
         };
 
         if p.gapless


### PR DESCRIPTION
Closes #32 (first lever).

## Summary

Pooled `dada` peak RSS jumps 28.8 GB (k5) → 53.8 GB (k7) on PacBio because it
holds a `Raw` for every unique across all samples resident, and the `4^k` k-mer
screen arrays grow 16× from k5→k7.

The exact **16-bit** frequency vector (`Raw.kmer`, `4^k × 2` bytes = **32 KB/unique
at k7**, the single largest k-mer term) is only read on the `kmer_dist8` overflow
fallback — which needs the *same* k-mer occurring **≥255× in both** sequences
(`m = a.min(b); if m == 255`), essentially never for amplicon data. So it doesn't
need to be resident.

## Change
- Remove `kmer: Option<Vec<u16>>` from `Raw`; `raw_assign_kmers` now builds only
  `kmer8` (the u8 screen) and `kord`.
- On the rare overflow path, recompute the u16 vectors from `seq` in
  `raw_align_with_buf`.
- The no-8-bit-vectors branch (cluster-center raws in `build_trans_mat`) keeps
  `kdist = 0.0` exactly as before — `kmer8` and the old u16 `kmer` were always
  absent together, so this preserves "no screen when vectors absent."

## Correctness
Byte-identical screening result: the overflow path recomputes the same value the
stored vector held, and the missing-vector path is unchanged. Full suite green
(42 unit + 12 integration, incl. the dada snapshot and derep-JSON parity tests);
clippy + fmt clean.

## Memory
Structural win — one `4^k`-u16 vector dropped per resident `Raw` (32 KB at k7,
2 KB at k5). **To be confirmed on the cluster**: re-measure pooled k7 peak; expect
the k5→k7 gap to shrink by the dropped u16 term (kmer8 u8 + kord remain). Doesn't
touch ASVs or the `dada` hot loop, so wall should be flat (overflow recompute is
off the hot path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)