### PR TITLE
perf(mem): make per-read Derep.map opt-in to shrink pooled derep peak (#36)

### DIFF
--- a/src/derep.rs
+++ b/src/derep.rs
@@ -53,11 +53,18 @@ pub fn checked_qual_sum(sum: f64) -> u32 {
 ///              read covers every position. Storing the sum is bit-identical to
 ///              the old f64 mean while using 4 bytes/position instead of 8.
 /// - `map`:     for each input read (in order), the index into `uniques` of the
-///              unique sequence it maps to.
+///              unique sequence it maps to. **Built only when requested** (see
+///              `build_map` in [`dereplicate`]); empty otherwise. It scales with
+///              the number of *reads* (8 bytes each), so it dominates resident
+///              memory for deep samples and is opt-in (issue #36). The read count
+///              is always available via `n_reads` regardless.
+/// - `n_reads`: total input reads (= Σ unique counts). Always populated, so read
+///              counts don't require the per-read `map`.
 pub struct Derep {
     pub uniques: Vec<(Vec<u8>, u64)>,
     pub quals: Vec<Vec<u32>>,
     pub map: Vec<usize>,
+    pub n_reads: u64,
 }
 
 /// Per-thread accumulator.  Can be merged in order to preserve read ordering.
@@ -68,10 +75,13 @@ struct PartialDerep {
     qual_sums: Vec<Vec<f64>>,
     qual_cnts: Vec<Vec<u64>>,
     map: Vec<usize>,
+    /// When false, the per-read `map` is not accumulated (issue #36) — uniques,
+    /// quals, and counts are unaffected.
+    build_map: bool,
 }
 
 impl PartialDerep {
-    fn new() -> Self {
+    fn new(build_map: bool) -> Self {
         Self {
             seq_order: Vec::new(),
             seq_to_idx: HashMap::new(),
@@ -79,6 +89,7 @@ impl PartialDerep {
             qual_sums: Vec::new(),
             qual_cnts: Vec::new(),
             map: Vec::new(),
+            build_map,
         }
     }
 
@@ -97,7 +108,9 @@ impl PartialDerep {
         };
 
         self.counts[idx] += 1;
-        self.map.push(idx);
+        if self.build_map {
+            self.map.push(idx);
+        }
 
         let sums = &mut self.qual_sums[idx];
         let cnts = &mut self.qual_cnts[idx];
@@ -146,8 +159,10 @@ impl PartialDerep {
             remap[i] = idx;
         }
 
-        for &local_idx in &other.map {
-            self.map.push(remap[local_idx]);
+        if self.build_map {
+            for &local_idx in &other.map {
+                self.map.push(remap[local_idx]);
+            }
         }
 
         self
@@ -199,7 +214,14 @@ impl PartialDerep {
             new_counts.push(self.counts[old_idx]);
             new_quals.push(quals_iter[old_idx].take().unwrap());
         }
-        let map: Vec<usize> = self.map.into_iter().map(|i| old_to_new[i]).collect();
+        // Read count is the sum of per-unique counts — always exact, and
+        // independent of whether the per-read map was built (issue #36).
+        let n_reads: u64 = new_counts.iter().sum();
+        let map: Vec<usize> = if self.build_map {
+            self.map.into_iter().map(|i| old_to_new[i]).collect()
+        } else {
+            Vec::new()
+        };
 
         let uniques = new_seq_order.into_iter().zip(new_counts).collect();
 
@@ -207,6 +229,7 @@ impl PartialDerep {
             uniques,
             quals: new_quals,
             map,
+            n_reads,
         }
     }
 }
@@ -214,16 +237,26 @@ impl PartialDerep {
 /// Records assigned to each thread per chunk — total chunk size scales with thread count.
 const RECORDS_PER_THREAD: usize = 10_000;
 
+/// Dereplicate a FASTQ stream into unique sequences with per-position quality
+/// sums and read counts.
+///
+/// `build_map`: when `true`, also record the per-read → unique-index `map`
+/// (needed only for read-level traceback, e.g. the `derep --show-map` output;
+/// `merge-pairs` builds its own internally). When `false`, the `map` is skipped
+/// entirely — it scales with read count (8 bytes/read) and dominates resident
+/// memory for deep pooled runs (issue #36). Uniques/quals/counts are identical
+/// either way; the read count is always available via `Derep::n_reads`.
 pub fn dereplicate<R: io::Read>(
     reader: R,
     phred_offset: u8,
+    build_map: bool,
     pool: &rayon::ThreadPool,
     verbose: bool,
 ) -> io::Result<Derep> {
     let chunk_size = RECORDS_PER_THREAD * pool.current_num_threads();
     let buf = BufReader::new(reader);
     let mut fastq_reader = fastq::io::Reader::new(buf);
-    let mut overall = PartialDerep::new();
+    let mut overall = PartialDerep::new(build_map);
 
     loop {
         // Read a chunk sequentially — the reader is a stream and cannot be shared.
@@ -255,11 +288,14 @@ pub fn dereplicate<R: io::Read>(
         let partial = pool.install(|| {
             chunk
                 .par_iter()
-                .fold(PartialDerep::new, |mut acc, (seq, qual)| {
-                    acc.add_record(seq.clone(), qual, phred_offset);
-                    acc
-                })
-                .reduce(PartialDerep::new, PartialDerep::merge)
+                .fold(
+                    || PartialDerep::new(build_map),
+                    |mut acc, (seq, qual)| {
+                        acc.add_record(seq.clone(), qual, phred_offset);
+                        acc
+                    },
+                )
+                .reduce(|| PartialDerep::new(build_map), PartialDerep::merge)
         });
 
         overall = overall.merge(partial);
@@ -273,7 +309,7 @@ pub fn dereplicate<R: io::Read>(
     if verbose {
         eprintln!(
             "[derep] {} raw sequences -> {} unique sequences",
-            derep.map.len(),
+            derep.n_reads,
             derep.uniques.len()
         );
     }

--- a/src/learn_errors.rs
+++ b/src/learn_errors.rs
@@ -293,11 +293,12 @@ pub fn load_fastq_samples(
             dereplicate(
                 MultiGzDecoder::new(File::open(path)?),
                 phred_offset,
+                false, // learn-errors uses uniques+quals only, not the per-read map (#36)
                 pool,
                 verbose,
             )?
         } else {
-            dereplicate(File::open(path)?, phred_offset, pool, verbose)?
+            dereplicate(File::open(path)?, phred_offset, false, pool, verbose)?
         };
 
         let file_bases: u64 = derep

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,7 @@ fn main() -> io::Result<()> {
                 dereplicate(
                     MultiGzDecoder::new(File::open(&input).with_path(&input)?),
                     phred_offset,
+                    show_map, // per-read map only needed for --show-map output (#36)
                     &pool,
                     verbose,
                 )?
@@ -274,6 +275,7 @@ fn main() -> io::Result<()> {
                 dereplicate(
                     File::open(&input).with_path(&input)?,
                     phred_offset,
+                    show_map,
                     &pool,
                     verbose,
                 )?
@@ -314,7 +316,7 @@ fn main() -> io::Result<()> {
             let sample = sample_name.unwrap_or_else(|| fastq_stem(&input));
             let derep_out = DerepOutput {
                 sample: &sample,
-                total_reads: derep.map.len(),
+                total_reads: derep.n_reads as usize,
                 unique_sequences: derep.uniques.len(),
                 sort_order: "abundance_desc",
                 uniques: uniq_entries,
@@ -2205,6 +2207,7 @@ fn main() -> io::Result<()> {
                     dereplicate(
                         MultiGzDecoder::new(File::open(path).with_path(path)?),
                         phred_offset,
+                        false, // sample output uses read counts (n_reads), not the map (#36)
                         &pool,
                         verbose,
                     )?
@@ -2212,6 +2215,7 @@ fn main() -> io::Result<()> {
                     dereplicate(
                         File::open(path).with_path(path)?,
                         phred_offset,
+                        false,
                         &pool,
                         verbose,
                     )?
@@ -2222,7 +2226,7 @@ fn main() -> io::Result<()> {
                     .iter()
                     .map(|(seq, count)| seq.len() as u64 * count)
                     .sum();
-                let file_reads: u64 = derep.map.len() as u64;
+                let file_reads: u64 = derep.n_reads;
 
                 // Build a stem for the output filename, stripping up to two extensions.
                 let stem = {
@@ -2254,7 +2258,7 @@ fn main() -> io::Result<()> {
                 }
                 let sample_out = DerepOutput {
                     sample: &stem,
-                    total_reads: derep.map.len(),
+                    total_reads: derep.n_reads as usize,
                     unique_sequences: uniq_entries.len(),
                     sort_order: "abundance_desc",
                     uniques: uniq_entries,
@@ -3880,11 +3884,13 @@ fn load_derep_for_dada(
             uniques.push((u.sequence.into_bytes(), u.count));
             quals.push(u.qual_sum);
         }
+        let n_reads: u64 = uniques.iter().map(|(_, c)| c).sum();
         Ok((
             derep::Derep {
                 uniques,
                 quals,
                 map: Vec::new(),
+                n_reads,
             },
             sample_name,
         ))
@@ -3892,6 +3898,7 @@ fn load_derep_for_dada(
         let derep = dereplicate(
             MultiGzDecoder::new(File::open(path).with_path(path)?),
             phred_offset,
+            false, // dada consumes uniques only; per-read map not needed (#36)
             pool,
             verbose,
         )?;
@@ -3900,6 +3907,7 @@ fn load_derep_for_dada(
         let derep = dereplicate(
             File::open(path).with_path(path)?,
             phred_offset,
+            false,
             pool,
             verbose,
         )?;

--- a/src/merge_pairs.rs
+++ b/src/merge_pairs.rs
@@ -402,6 +402,7 @@ pub fn merge_sample(
         dereplicate(
             MultiGzDecoder::new(File::open(fwd_fastq_path)?),
             params.phred_offset,
+            true, // merge-pairs pairs reads via this map (#36)
             pool,
             params.verbose,
         )?
@@ -409,6 +410,7 @@ pub fn merge_sample(
         dereplicate(
             File::open(fwd_fastq_path)?,
             params.phred_offset,
+            true,
             pool,
             params.verbose,
         )?
@@ -418,6 +420,7 @@ pub fn merge_sample(
         dereplicate(
             MultiGzDecoder::new(File::open(rev_fastq_path)?),
             params.phred_offset,
+            true, // merge-pairs pairs reads via this map (#36)
             pool,
             params.verbose,
         )?
@@ -425,6 +428,7 @@ pub fn merge_sample(
         dereplicate(
             File::open(rev_fastq_path)?,
             params.phred_offset,
+            true,
             pool,
             params.verbose,
         )?


### PR DESCRIPTION
Addresses #36 (lever 1).

## Summary

The phase-RSS instrumentation (#32 profiling) showed the `dada-pooled` peak is set
during **dereplication**, before `run_dada` builds anything — because every
sample's `Derep` is held resident through the cross-sample merge, and `Derep.map`
(one `usize` = 8 bytes per **input read**) dominates that footprint for deep
samples.

The pipeline-passed `map` is **never read as a map** except by `derep --show-map`:
- `dada-pooled` / `dada` / `dada-pseudo` consume `uniques` only;
- every other use is just `map.len()` (a read count);
- `merge-pairs` builds its **own** map internally from the FASTQs it already
  requires (merge_pairs.rs `dereplicate()` calls) — it never uses the upstream map.

## Change
- `dereplicate()` gains `build_map: bool`; when `false`, the per-read map is never
  accumulated (less memory **and** a little less work).
- Callers: dada-pooled / dada / dada-pseudo / sample / learn-errors → `false`;
  `derep` → `show_map`; merge-pairs internal derep → `true`.
- `Derep` gains `n_reads` (= Σ unique counts), always populated, so read counts and
  the verbose log don't need the map.

## Correctness
`uniques`/`quals`/ASVs are byte-identical regardless of `build_map` (the map is a
pure read→unique trace, independent of the other outputs). Verified:
- full suite green (42 unit + 12 integration, incl. derep-JSON parity + merge-pairs);
- `derep` default now **omits** the map (was always emitted); `--show-map` still
  emits the full per-read map; `total_reads` correct in both; uniques identical.

## Memory
To be measured on the cluster via the #32 `--verbose` phase-RSS logging — expect
the **derep** high-water mark to drop by roughly `8 bytes × reads × samples`
(plausibly a large share of the ~3 GB seen locally). No ASV/wall change expected;
possible small bandwidth bonus from the lighter resident set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)