### PR TITLE
perf/mem: sparse kmer8 screen, gated to k≥8 (#43)

### DIFF
--- a/src/containers.rs
+++ b/src/containers.rs
@@ -1,3 +1,5 @@
+use crate::kmers::KmerScreen;
+
 /// Default initial cluster buffer size (mirrors C++ RAWBUF / CLUSTBUF).
 /// Vec growth is automatic in Rust so this only affects the initial allocation.
 const INIT_RAWS_CAPACITY: usize = 50;
@@ -81,13 +83,14 @@ pub struct Raw {
     pub qual: Option<Vec<u8>>,
     /// Prior reasons to expect this sequence to be genuine.
     pub prior: bool,
-    /// 8-bit compressed k-mer frequency vector; populated by kmers module. This
-    /// is the resident k-mer screen. The exact 16-bit frequency vector is NOT
-    /// stored (issue #32: it dominated pooled RSS at k7, ~4^k × 2 bytes/unique,
-    /// and is only needed when `kmer_dist8` overflows — a k-mer occurring ≥255×
-    /// in both sequences, essentially never for amplicons); on that path it is
-    /// recomputed from `seq` in `raw_align_with_buf`.
-    pub kmer8: Option<Vec<u8>>,
+    /// 8-bit compressed k-mer frequency screen; populated by kmers module. This
+    /// is the resident k-mer screen, stored dense for small k and sparsely for
+    /// k ≥ `SPARSE_KMER_MIN` (issue #43, since the dense `4^k` array dominated
+    /// pooled RSS at k7). The exact 16-bit frequency vector is NOT stored (issue
+    /// #32: it is only needed when `kmer_dist8` overflows — a k-mer occurring
+    /// ≥255× in both sequences, essentially never for amplicons); on that path
+    /// it is recomputed from `seq` in `raw_align_with_buf`.
+    pub kmer8: Option<KmerScreen>,
     /// K-mers in the order they appear along the sequence; populated by kmers module.
     pub kord: Option<Vec<u16>>,
     /// Number of reads of this unique sequence.

--- a/src/dada.rs
+++ b/src/dada.rs
@@ -339,6 +339,48 @@ pub fn dada_uniques_cached(
                         0.0
                     },
                 );
+
+                // K-mer complexity / diversity diagnostics (#43). Two signals:
+                //  - per-Raw FILL = distinct k-mers / positional max (len-k+1).
+                //    ~100% for high-complexity amplicon reads; a low value flags
+                //    low-complexity/repetitive sequence content.
+                //  - pooled DIVERSITY = union of distinct k-mers across all
+                //    uniques vs the 4^k space, plus mean sharing (Σ positional /
+                //    union). High sharing = tight homologous amplicon; low
+                //    sharing + high occupancy flags diverse/contaminated or
+                //    over-amplified data (inflated PCR error/chimera k-mers, not
+                //    biological diversity). Cost: one 4^k-bit presence bitmap
+                //    (≤8 KB through k8) + a single pass over the screens.
+                if nr > 0 && raws.iter().any(|r| r.kmer8.is_some()) {
+                    let nk = crate::kmers::n_kmers(k);
+                    let mut bitmap = vec![0u64; nk.div_ceil(64)];
+                    let mut distinct_sum = 0usize; // Σ per-raw distinct k-mers
+                    let mut positional_sum = 0usize; // Σ (len - k + 1)
+                    for r in &raws {
+                        if let Some(screen) = &r.kmer8 {
+                            distinct_sum += screen.distinct_kmers();
+                            positional_sum += r.len().saturating_sub(k - 1);
+                            screen.for_each_present_index(|idx| {
+                                bitmap[idx >> 6] |= 1u64 << (idx & 63);
+                            });
+                        }
+                    }
+                    let union: usize = bitmap.iter().map(|w| w.count_ones() as usize).sum();
+                    let fill_pct = 100.0 * distinct_sum as f64 / positional_sum.max(1) as f64;
+                    let dense_pct = 100.0 * distinct_sum as f64 / (nr as f64 * nk as f64);
+                    eprintln!(
+                        "[dada] kmer8 fill: mean {:.0} / {:.0} distinct k-mers/raw \
+                         ({fill_pct:.1}% of positional max), {dense_pct:.1}% of dense 4^k [k={k}]",
+                        distinct_sum as f64 / nr as f64,
+                        positional_sum as f64 / nr as f64,
+                    );
+                    eprintln!(
+                        "[dada] kmer8 pooled diversity: {union} distinct k-mers \
+                         ({:.1}% of 4^k space), mean sharing {:.0}× across {nr} uniques",
+                        100.0 * union as f64 / nk as f64,
+                        positional_sum as f64 / union.max(1) as f64,
+                    );
+                }
             }
             raws
         }

--- a/src/dada.rs
+++ b/src/dada.rs
@@ -318,14 +318,19 @@ pub fn dada_uniques_cached(
                 let nr = raws.len();
                 let (mut kmer_b, mut seq_b) = (0usize, 0usize);
                 for r in &raws {
-                    kmer_b += r.kmer8.as_ref().map_or(0, |v| v.len())
+                    kmer_b += r.kmer8.as_ref().map_or(0, |v| v.resident_bytes())
                         + r.kord.as_ref().map_or(0, |v| v.len() * 2);
                     seq_b += r.seq.len() + r.qual.as_ref().map_or(0, |q| q.len());
                 }
                 let mb = |b: usize| b as f64 / (1024.0 * 1024.0);
+                let screen_repr = if k >= crate::kmers::SPARSE_KMER_MIN {
+                    "sparse #43"
+                } else {
+                    "dense"
+                };
                 eprintln!(
                     "[dada] resident Raw footprint: {nr} raws, seq+qual {:.1} MB, \
-                     k-mer vectors {:.1} MB ({:.0} B/raw) [k={k}; u16 k-mer freq not stored, #32]",
+                     k-mer vectors {:.1} MB ({:.0} B/raw) [k={k}; kmer8 {screen_repr}; u16 k-mer freq not stored, #32]",
                     mb(seq_b),
                     mb(kmer_b),
                     if nr > 0 {

--- a/src/kmers.rs
+++ b/src/kmers.rs
@@ -163,6 +163,37 @@ impl KmerScreen {
             KmerScreen::Sparse(v) => v.len() * std::mem::size_of::<(u16, u8)>(),
         }
     }
+
+    /// Number of *distinct* k-mers present in this sequence (sparse entries, or
+    /// dense nonzero buckets). Bounded by `len - k + 1`; below that signals
+    /// low-complexity/repetitive content. For `--verbose` diagnostics (#43).
+    #[inline]
+    pub fn distinct_kmers(&self) -> usize {
+        match self {
+            KmerScreen::Dense(v) => v.iter().filter(|&&c| c > 0).count(),
+            KmerScreen::Sparse(v) => v.len(),
+        }
+    }
+
+    /// Invoke `f` with each present k-mer index, for tallying the pooled union
+    /// of distinct k-mers across all uniques (`--verbose` diagnostics, #43).
+    #[inline]
+    pub fn for_each_present_index<F: FnMut(usize)>(&self, mut f: F) {
+        match self {
+            KmerScreen::Dense(v) => {
+                for (i, &c) in v.iter().enumerate() {
+                    if c > 0 {
+                        f(i);
+                    }
+                }
+            }
+            KmerScreen::Sparse(v) => {
+                for &(idx, _) in v {
+                    f(idx as usize);
+                }
+            }
+        }
+    }
 }
 
 /// Populate the resident k-mer screen fields (`kmer8`, `kord`) on a `Raw`.

--- a/src/kmers.rs
+++ b/src/kmers.rs
@@ -27,14 +27,22 @@ pub const KMER_SIZE_MIN: usize = 3;
 pub const KMER_SIZE_MAX: usize = 8;
 
 /// Smallest k for which the resident 8-bit k-mer screen is stored *sparsely*
-/// (issue #43). Below this, the dense `4^k` array is small (≤1 KB at k5) and
-/// nearly fully populated, so the dense `sum-of-min` loop (which auto-vectorises)
-/// is both smaller and faster. At k≥6 the dense array is ≥4 KB and increasingly
-/// zero-dominated (a ~1.5 kb read has only ~seqlen distinct k-mers), so a sparse
-/// `(index, count)` representation cuts resident RSS sharply — at the cost of a
-/// merge-join distance instead of a dense sweep. Dense ≤ k5 keeps the
-/// Illumina/default path byte-identical and untouched.
-pub const SPARSE_KMER_MIN: usize = 6;
+/// (issue #43). The sparse `(index, count)` representation costs a fixed
+/// ~6 KB/raw (≈seqlen entries), independent of k, whereas the dense `4^k` array
+/// grows as `4^k`. The PacBio 93-sample pooled A/B (dense vs sparse, per k)
+/// pinned the crossover precisely at where `4^k` passes ~6 KB:
+///   - k5 (1 KB) / k6 (4 KB): dense is *smaller* than sparse, and its contiguous
+///     `sum-of-min` sweep is cache-resident + auto-vectorised, so dense wins both
+///     memory and wall (k6 sparse regressed +20.8% RSS *and* +20.1% dada wall).
+///   - k7 (16 KB): sparse wins RSS (−22.6%) but 16 KB still fits cache, so the
+///     dense sweep beats the branchy merge-join → +25.7% dada wall. A tradeoff,
+///     and k7 is the production default — so we keep it dense.
+///   - k8 (64 KB): dense spills cache; merge-join wins *both* (−68.3% RSS,
+///     −17.3% wall) and makes k8 feasible at all (42.8 GB dense → 13.6 GB).
+///
+/// So sparse is gated to k≥8, where it is a pure win with no regression at any
+/// smaller k; k≤7 keeps the byte-identical dense path.
+pub const SPARSE_KMER_MIN: usize = 8;
 
 /// Number of possible k-mers for a given k: 4^k = 1 << (2*k).
 #[inline]

--- a/src/kmers.rs
+++ b/src/kmers.rs
@@ -11,6 +11,7 @@
 //! i.e. `index = sum over positions of (nt - 1) * 4^(k-1-i)`.
 
 use crate::containers::Raw;
+use std::cmp::Ordering;
 
 /// Default k-mer size, matching the C++ `KMER_SIZE` constant in `dada.h`.
 /// At runtime this is overridable via `AlignParams::kmer_size`; the const is
@@ -24,6 +25,16 @@ pub const KMER_SIZE: usize = 5;
 /// and matches the C++ assumption).
 pub const KMER_SIZE_MIN: usize = 3;
 pub const KMER_SIZE_MAX: usize = 8;
+
+/// Smallest k for which the resident 8-bit k-mer screen is stored *sparsely*
+/// (issue #43). Below this, the dense `4^k` array is small (≤1 KB at k5) and
+/// nearly fully populated, so the dense `sum-of-min` loop (which auto-vectorises)
+/// is both smaller and faster. At k≥6 the dense array is ≥4 KB and increasingly
+/// zero-dominated (a ~1.5 kb read has only ~seqlen distinct k-mers), so a sparse
+/// `(index, count)` representation cuts resident RSS sharply — at the cost of a
+/// merge-join distance instead of a dense sweep. Dense ≤ k5 keeps the
+/// Illumina/default path byte-identical and untouched.
+pub const SPARSE_KMER_MIN: usize = 6;
 
 /// Number of possible k-mers for a given k: 4^k = 1 << (2*k).
 #[inline]
@@ -81,6 +92,25 @@ pub fn assign_kmer8(seq: &[u8], k: usize) -> Vec<u8> {
         .collect()
 }
 
+/// Build a *sparse* 8-bit k-mer screen: sorted `(kmer_index, count)` pairs for
+/// the k-mers actually present in `seq`, counts saturating at 255 (issue #43).
+///
+/// The index fits `u16` for all supported k (`4^8 = 65536` ≤ `u16::MAX + 1`,
+/// the largest index being `4^k - 1 = 65535` at k=8). Entries are emitted in
+/// ascending index order (a dense scan), which the merge-join in
+/// [`kmer_dist8_sparse`] relies on. Built via the dense `u16` vector then
+/// filtered; the dense intermediate is transient (freed per call, bounded by
+/// thread count), while the resident result is ~`seqlen` entries instead of
+/// `4^k` bytes — the whole point at large k.
+pub fn assign_kmer8_sparse(seq: &[u8], k: usize) -> Vec<(u16, u8)> {
+    assign_kmer(seq, k)
+        .into_iter()
+        .enumerate()
+        .filter(|&(_, c)| c > 0)
+        .map(|(idx, c)| (idx as u16, c.min(255) as u8))
+        .collect()
+}
+
 /// Build the ordered k-mer vector: the k-mer index at each sequence position.
 ///
 /// `kord[i]` is the index of the k-mer starting at position `i`. Positions
@@ -96,13 +126,58 @@ pub fn assign_kmer_order(seq: &[u8], k: usize) -> Vec<u16> {
         .collect()
 }
 
+/// Resident 8-bit k-mer screen representation (issue #43).
+///
+/// `Dense` is the classic `4^k`-byte frequency array (used for k < [`SPARSE_KMER_MIN`]);
+/// `Sparse` is sorted `(index, count)` pairs for present k-mers only (k ≥
+/// `SPARSE_KMER_MIN`). Both yield identical [`kmer_dist8`] results — `Sparse`
+/// merely skips the buckets where the dense `min` would be zero.
+#[derive(Clone)]
+pub enum KmerScreen {
+    Dense(Vec<u8>),
+    Sparse(Vec<(u16, u8)>),
+}
+
+impl KmerScreen {
+    /// 8-bit k-mer distance against another screen of the same representation.
+    ///
+    /// Returns `-1.0` on saturation overflow (a k-mer at ≥255 in *both* seqs),
+    /// matching [`kmer_dist8`]. Both raws in a run share `k`, hence the same
+    /// variant; mixed variants are a programming error.
+    #[inline]
+    pub fn dist8(&self, other: &KmerScreen, len1: usize, len2: usize, k: usize) -> f64 {
+        match (self, other) {
+            (KmerScreen::Dense(a), KmerScreen::Dense(b)) => kmer_dist8(a, len1, b, len2, k),
+            (KmerScreen::Sparse(a), KmerScreen::Sparse(b)) => {
+                kmer_dist8_sparse(a, len1, b, len2, k)
+            }
+            _ => unreachable!("mixed dense/sparse k-mer screens (k must be uniform per run)"),
+        }
+    }
+
+    /// Resident byte footprint of this screen (for `--verbose` accounting).
+    #[inline]
+    pub fn resident_bytes(&self) -> usize {
+        match self {
+            KmerScreen::Dense(v) => v.len(),
+            KmerScreen::Sparse(v) => v.len() * std::mem::size_of::<(u16, u8)>(),
+        }
+    }
+}
+
 /// Populate the resident k-mer screen fields (`kmer8`, `kord`) on a `Raw`.
 ///
 /// The exact 16-bit frequency vector is intentionally NOT stored (issue #32):
 /// it dominated pooled RSS at k7 and is only consulted on the `kmer_dist8`
 /// overflow fallback, where it is recomputed from `seq` via [`assign_kmer`].
+/// The screen is stored sparsely for k ≥ [`SPARSE_KMER_MIN`] (issue #43).
 pub fn raw_assign_kmers(raw: &mut Raw, k: usize) {
-    raw.kmer8 = Some(assign_kmer8(&raw.seq, k));
+    let screen = if k >= SPARSE_KMER_MIN {
+        KmerScreen::Sparse(assign_kmer8_sparse(&raw.seq, k))
+    } else {
+        KmerScreen::Dense(assign_kmer8(&raw.seq, k))
+    };
+    raw.kmer8 = Some(screen);
     raw.kord = Some(assign_kmer_order(&raw.seq, k));
 }
 
@@ -154,6 +229,45 @@ pub fn kmer_dist8(kv1: &[u8], len1: usize, kv2: &[u8], len2: usize, k: usize) ->
     1.0 - dotsum as f64 / scale
 }
 
+/// Sparse counterpart of [`kmer_dist8`] over sorted `(index, count)` pairs
+/// (issue #43).
+///
+/// The dense distance is `1 - Σ min(a[i], b[i]) / scale`; `min` is zero at any
+/// bucket where either count is zero, so only k-mers present in *both* sequences
+/// contribute. A merge-join over the two ascending-index vectors visits exactly
+/// those, giving a result bit-identical to the dense path while touching
+/// ~`seqlen` entries instead of `4^k`. Overflow (`min == 255`) is detected on the
+/// matching buckets, the only place a saturated `min` can arise.
+pub fn kmer_dist8_sparse(
+    kv1: &[(u16, u8)],
+    len1: usize,
+    kv2: &[(u16, u8)],
+    len2: usize,
+    k: usize,
+) -> f64 {
+    let mut dotsum = 0u32;
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < kv1.len() && j < kv2.len() {
+        let (ai, ac) = kv1[i];
+        let (bi, bc) = kv2[j];
+        match ai.cmp(&bi) {
+            Ordering::Less => i += 1,
+            Ordering::Greater => j += 1,
+            Ordering::Equal => {
+                let m = ac.min(bc);
+                if m == 255 {
+                    return -1.0;
+                }
+                dotsum += m as u32;
+                i += 1;
+                j += 1;
+            }
+        }
+    }
+    let scale = (len1.min(len2) - k + 1) as f64;
+    1.0 - dotsum as f64 / scale
+}
+
 /// Ordered k-mer distance (fraction of positionally mismatched k-mers).
 ///
 /// Returns `-1.0` if the sequence lengths differ.
@@ -172,6 +286,80 @@ pub fn kord_dist(kord1: &[u16], len1: usize, kord2: &[u16], len2: usize, k: usiz
         .map(|(a, b)| (a == b) as u32)
         .sum();
     1.0 - dotsum as f64 / klen as f64
+}
+
+#[cfg(test)]
+mod sparse_tests {
+    use super::*;
+
+    // Deterministic pseudo-random ACGT (1..=4) sequence.
+    fn make_seq(n: usize, seed: u64) -> Vec<u8> {
+        let mut s = seed;
+        (0..n)
+            .map(|_| {
+                s = s
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                ((s >> 33) % 4) as u8 + 1
+            })
+            .collect()
+    }
+
+    /// Sparse builder must round-trip to the dense vector exactly.
+    #[test]
+    fn sparse_reconstructs_dense() {
+        for &k in &[6usize, 7, 8] {
+            for seed in 0..8 {
+                let seq = make_seq(300, seed);
+                let dense = assign_kmer8(&seq, k);
+                let sparse = assign_kmer8_sparse(&seq, k);
+                // ascending, unique indices
+                assert!(sparse.windows(2).all(|w| w[0].0 < w[1].0));
+                let mut reconstructed = vec![0u8; n_kmers(k)];
+                for &(idx, c) in &sparse {
+                    reconstructed[idx as usize] = c;
+                }
+                assert_eq!(dense, reconstructed, "k={k} seed={seed}");
+            }
+        }
+    }
+
+    /// Sparse merge-join distance must be bit-identical to the dense sweep.
+    #[test]
+    fn sparse_dist_matches_dense() {
+        for &k in &[6usize, 7, 8] {
+            for seed in 0..16 {
+                let a = make_seq(250, seed);
+                let b = make_seq(250, seed + 100);
+                let (da, db) = (assign_kmer8(&a, k), assign_kmer8(&b, k));
+                let (sa, sb) = (assign_kmer8_sparse(&a, k), assign_kmer8_sparse(&b, k));
+                let dense = kmer_dist8(&da, a.len(), &db, b.len(), k);
+                let sparse = kmer_dist8_sparse(&sa, a.len(), &sb, b.len(), k);
+                assert_eq!(dense.to_bits(), sparse.to_bits(), "k={k} seed={seed}");
+                // identical sequences → distance 0
+                let sparse_self = kmer_dist8_sparse(&sa, a.len(), &sa, a.len(), k);
+                assert_eq!(
+                    sparse_self.to_bits(),
+                    0.0f64.to_bits(),
+                    "self k={k} seed={seed}"
+                );
+            }
+        }
+    }
+
+    /// Overflow (a k-mer at ≥255 in both seqs) must return -1.0 in both paths.
+    #[test]
+    fn sparse_dist_overflow_matches_dense() {
+        let k = 6;
+        // a 300-A homopolymer: the all-A k-mer occurs 295× (>255) → saturates
+        let seq = vec![1u8; 300];
+        let dense = assign_kmer8(&seq, k);
+        let sparse = assign_kmer8_sparse(&seq, k);
+        let d = kmer_dist8(&dense, seq.len(), &dense, seq.len(), k);
+        let s = kmer_dist8_sparse(&sparse, seq.len(), &sparse, seq.len(), k);
+        assert_eq!(d, -1.0);
+        assert_eq!(s, -1.0);
+    }
 }
 
 #[cfg(test)]

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -12,7 +12,7 @@
 //! Traceback pointer values: `1` = diagonal, `2` = left (gap in s1), `3` = up (gap in s2).
 
 use crate::containers::{Raw, Sub};
-use crate::kmers::{assign_kmer, kmer_dist, kmer_dist8, kord_dist};
+use crate::kmers::{assign_kmer, kmer_dist, kord_dist};
 
 /// Sentinel used in `Sub::map` to indicate that a reference position aligns
 /// to a gap in the query.  Matches C++ `GAP_GLYPH = 9999`.
@@ -1124,7 +1124,7 @@ pub fn raw_align_with_buf(
         // Prefer 8-bit kmer distance; fall back to 16-bit on overflow.
         kdist = match (&raw1.kmer8, &raw2.kmer8) {
             (Some(k1), Some(k2)) => {
-                let d8 = kmer_dist8(k1, raw1.len(), k2, raw2.len(), k);
+                let d8 = k1.dist8(k2, raw1.len(), raw2.len(), k);
                 if d8 < 0.0 {
                     // Overflow (a k-mer occurs ≥255× in both seqs): fall back to
                     // the exact 16-bit distance. The u16 vectors are not kept


### PR DESCRIPTION
Closes #43.

Replaces the dense `4^k`-byte k-mer screen array with a sparse `(index, count)` representation whose footprint tracks sequence length instead of `4^k` — gated to the k where it is a measured **pure win**.

## Background
After #39/#40/#41 made the pooled merge phase cheap, the pooled k7 peak was dominated by the resident k-mer screen: dense `kmer8` = `4^7` = 16384 B/raw, ~90% zeros (a ~1.5 kb read has only ~seqlen distinct 7-mers). At 547k pooled uniques that's ~8.7 GB = 57% of the 17.6 GB peak.

## What's here
- **`KmerScreen` enum** (`Dense(Vec<u8>)` / `Sparse(Vec<(u16,u8)>)`) replaces `Raw.kmer8: Option<Vec<u8>>`.
- **`kmer_dist8_sparse`**: merge-join over ascending-index pairs — only buckets present in both contribute, so it is **bit-identical** to the dense sum-of-min (including the ≥255 overflow sentinel). Unit tests assert sparse≡dense (build round-trip, distance bits, self=0, overflow=-1).
- **Verbose diagnostics** (concordance-neutral): per-Raw k-mer "fill" (distinct vs positional worst-case) and pooled "diversity" (union / occupancy / mean sharing) — surfaces over-amplified samples (inflated PCR-error/chimera k-mers vs biological diversity).

## Why gated to k≥8
Sparse costs a fixed ~6 KB/raw; dense costs `4^k`. The PacBio 93-sample pooled A/B (dense `main` vs sparse, per k) pins the crossover exactly where `4^k` passes ~6 KB:

| k | dense 4^k | dada wall Δ | dada RSS Δ | RSS pre→post |
|---|---|---|---|---|
| 5 | 1 KB | −0.1% | −0.1% | 9.85→9.84 GB (dense both sides, sanity) |
| 6 | 4 KB | **+20.1%** | **+20.8%** | 11.65→14.07 GB (sparse *bigger* + slower) |
| 7 | 16 KB | **+25.7%** | −22.6% | 17.80→13.77 GB (mem win, but cache-fit dense sweep beats merge-join; k7 is prod default) |
| 8 | 64 KB | **−17.3%** | **−68.3%** | 42.80→13.58 GB (dense spills cache → merge-join wins both; k8 feasible at all) |

So `SPARSE_KMER_MIN = 8`: sparse only where it is a pure win, no regression at any smaller k, **k≤7 keeps the byte-identical dense path**. Note the floor is now k-independent for sparse (k7 13.77 ≈ k8 13.58 GB) — footprint decoupled from `4^k` as intended; the residual is the seq term (#28).

## Concordance
`scripts/compare_asvs.py` churn=**0** at k5/k6/k7/k8 on the 93-sample pooled set — k8 sparse ≡ k8 dense at the ASV level (2077/2080/2082/2081 ASVs, `only_pre=only_post=0`).

## Follow-up
#44 (experimental): sparse decoupled resident size from `4^k`, so the `KMER_SIZE_MAX = 8` cap is now just an index-width artifact — worth raising experimentally, gated on a mock-community truth set (the extra ASVs are the hypothesis to disprove, not the win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)