### PR TITLE
docs: rename nav entry to "Building & installing"

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-# Installation
+# Building & installing
 
 ## Prerequisites
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - About: about.md
-  - Installation: installation.md
+  - Building & installing: installation.md
   - Walkthroughs:
     - Illumina MiSeq: walkthrough-illumina.md
     - PacBio HiFi: walkthrough-pacbio.md


### PR DESCRIPTION
Relabel the docs nav entry (and page H1) `Installation` → `Building & installing`, since the page now covers build/task-runner tasks as well as installation. Filename unchanged, so links and `edit_uri` still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)