### PR TITLE
feat(merge-pairs): input-file provenance + mismatch warning (#10)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -360,6 +360,8 @@ fn main() -> io::Result<()> {
             #[derive(Serialize)]
             struct DerepOutput<'a> {
                 sample: &'a str,
+                /// Original input file name (no directory) for provenance.
+                input_file: String,
                 total_reads: usize,
                 unique_sequences: usize,
                 /// "abundance_desc" — produced by `dereplicate()`; lets dada /
@@ -384,6 +386,7 @@ fn main() -> io::Result<()> {
             let sample = sample_name.unwrap_or_else(|| fastq_stem(&input));
             let derep_out = DerepOutput {
                 sample: &sample,
+                input_file: file_basename(&input),
                 total_reads: derep.map.len(),
                 unique_sequences: derep.uniques.len(),
                 sort_order: "abundance_desc",
@@ -585,6 +588,7 @@ fn main() -> io::Result<()> {
                     let json = denoise_and_serialize(
                         "dada",
                         &sample,
+                        &file_basename(path),
                         &raw_inputs,
                         &resolved.params,
                         &resolved.run,
@@ -775,6 +779,8 @@ fn main() -> io::Result<()> {
             #[derive(Serialize)]
             struct DadaOutput {
                 sample: String,
+                /// Original input file name (no directory) for provenance.
+                input_file: String,
                 num_asvs: usize,
                 total_reads: u32,
                 asvs: Vec<AsvEntry>,
@@ -845,6 +851,7 @@ fn main() -> io::Result<()> {
 
             let out = DadaOutput {
                 sample,
+                input_file: file_basename(input),
                 num_asvs: asvs.len(),
                 total_reads,
                 asvs,
@@ -1146,6 +1153,8 @@ fn main() -> io::Result<()> {
             #[derive(Serialize)]
             struct DadaOutput {
                 sample: String,
+                /// Original input file name (no directory) for provenance.
+                input_file: String,
                 num_asvs: usize,
                 total_reads: u32,
                 asvs: Vec<AsvEntry>,
@@ -1187,6 +1196,7 @@ fn main() -> io::Result<()> {
                 let n_asvs = asvs.len();
                 let out = DadaOutput {
                     sample: sample_name.clone(),
+                    input_file: file_basename(&input[s]),
                     num_asvs: n_asvs,
                     total_reads,
                     asvs,
@@ -1517,6 +1527,7 @@ fn main() -> io::Result<()> {
                     let json = denoise_and_serialize(
                         "dada-pseudo",
                         sample_name,
+                        &file_basename(&input[s]),
                         &sample_raws[s],
                         &resolved.params,
                         &resolved.run,
@@ -1548,6 +1559,7 @@ fn main() -> io::Result<()> {
                     let json = denoise_and_serialize(
                         "dada-pseudo",
                         sample_name,
+                        &file_basename(&input[s]),
                         &raws,
                         &resolved.params,
                         &resolved.run,
@@ -2276,6 +2288,8 @@ fn main() -> io::Result<()> {
             #[derive(Serialize)]
             struct DerepOutput<'a> {
                 sample: &'a str,
+                /// Original input file name (no directory) for provenance.
+                input_file: String,
                 total_reads: usize,
                 unique_sequences: usize,
                 sort_order: &'static str,
@@ -2348,6 +2362,7 @@ fn main() -> io::Result<()> {
                 }
                 let sample_out = DerepOutput {
                     sample: &stem,
+                    input_file: file_basename(path),
                     total_reads: derep.map.len(),
                     unique_sequences: uniq_entries.len(),
                     sort_order: "abundance_desc",
@@ -3855,6 +3870,7 @@ fn to_json<T: Serialize>(value: &T, compact: bool) -> io::Result<String> {
 fn denoise_and_serialize(
     tag: &'static str,
     sample: &str,
+    input_file: &str,
     raw_inputs: &[dada::RawInput],
     params: &dada::DadaParams,
     run_params: &DadaRunParams,
@@ -3865,6 +3881,8 @@ fn denoise_and_serialize(
     #[derive(Serialize)]
     struct DadaOutput {
         sample: String,
+        /// Original input file name (no directory) for provenance.
+        input_file: String,
         num_asvs: usize,
         total_reads: u32,
         asvs: Vec<AsvEntry>,
@@ -3899,6 +3917,7 @@ fn denoise_and_serialize(
 
     let out = DadaOutput {
         sample: sample.to_string(),
+        input_file: input_file.to_string(),
         num_asvs: asvs.len(),
         total_reads,
         asvs,
@@ -4022,6 +4041,16 @@ fn select_sequences(
             by_prev || by_abund
         })
         .collect()
+}
+
+/// Original file name without the directory path, for provenance. Recorded in
+/// dada/derep JSON so downstream commands (e.g. `merge-pairs`) can verify they
+/// were handed the file the JSON was actually computed from.
+fn file_basename(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 fn fastq_stem(path: &Path) -> String {

--- a/src/merge_pairs.rs
+++ b/src/merge_pairs.rs
@@ -98,6 +98,9 @@ struct AsvJson {
 struct DadaJsonInput {
     /// Sample identifier; absent in dada JSONs produced before --sample-name.
     sample: Option<String>,
+    /// Original FASTQ file name (no directory) this dada result was computed
+    /// from; absent in dada JSONs produced before provenance was recorded.
+    input_file: Option<String>,
     asvs: Vec<AsvJson>,
     /// unique-index → ASV-index mapping; absent in dada JSONs produced
     /// before the map became part of the default output.
@@ -275,6 +278,32 @@ fn build_merged(
     String::from_utf8_lossy(&result).into_owned()
 }
 
+/// Default-on provenance check: warn (to stderr) when the FASTQ a dada JSON
+/// records having been computed from does not match the FASTQ now being passed
+/// for that orientation. A mismatch usually means the four positional file
+/// lists have drifted out of alignment (e.g. a glob expanded to a different
+/// set), which would silently merge the wrong samples. This only warns —
+/// older dada JSONs without the recorded name are skipped.
+fn warn_on_input_mismatch(
+    label: &str,
+    recorded: Option<&str>,
+    fastq_path: &Path,
+    dada_path: &Path,
+) {
+    let Some(recorded) = recorded else { return };
+    let passed = fastq_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    if recorded != passed {
+        eprintln!(
+            "[merge-pairs] warning: {label} dada '{}' was computed from '{recorded}', \
+             but the {label} FASTQ passed is '{passed}' — check that the file lists line up",
+            dada_path.display(),
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Sample-ID sanity check
 // ---------------------------------------------------------------------------
@@ -355,6 +384,21 @@ pub fn merge_sample(
     let rev_dada: DadaJsonInput =
         crate::misc::read_tagged_json(rev_dada_path, &["dada", "dada-pooled", "dada-pseudo"])
             .with_path(rev_dada_path)?;
+
+    // Provenance warning (always on): does each dada JSON's recorded source
+    // FASTQ match the FASTQ now being passed for that orientation?
+    warn_on_input_mismatch(
+        "forward",
+        fwd_dada.input_file.as_deref(),
+        fwd_fastq_path,
+        fwd_dada_path,
+    );
+    warn_on_input_mismatch(
+        "reverse",
+        rev_dada.input_file.as_deref(),
+        rev_fastq_path,
+        rev_dada_path,
+    );
 
     if params.check_sample_ids {
         check_sample_ids(

--- a/tests/dada_pseudo.rs
+++ b/tests/dada_pseudo.rs
@@ -758,9 +758,17 @@ fn dada_from_fastq_matches_dada_from_derep_json() {
         from_json.to_str().unwrap(),
     ]);
 
+    // The `input_file` provenance field intentionally differs (the FASTQ name
+    // vs the derep JSON name); strip it before comparing the denoising result.
+    let strip_input_file = |path: &std::path::Path| {
+        let mut v: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        v.as_object_mut().unwrap().remove("input_file");
+        v
+    };
     assert_eq!(
-        std::fs::read(&from_fastq).unwrap(),
-        std::fs::read(&from_json).unwrap(),
+        strip_input_file(&from_fastq),
+        strip_input_file(&from_json),
         "dada output from derep JSON differs from dada output from FASTQ",
     );
 }


### PR DESCRIPTION
Closes #10.

## Problem
`merge-pairs` matches its four file lists (`--fwd-dada`, `--rev-dada`, `--fwd-fastq`, `--rev-fastq`) purely by position. A glob that expands to a slightly different set in one directory silently shifts everything and merges the wrong samples. The only guards were structural (equal list lengths, read counts, map sizes) plus the opt-in `--check-sample-ids`, none of which reliably catch positional drift by default.

## Change
- **Provenance:** record the original input file basename (no directory) as `input_file` in `dada`, `dada-pooled`, `dada-pseudo`, `derep`, and `sample` JSON outputs.
- **Default-on warning:** `merge-pairs` compares each dada JSON's recorded `input_file` against the basename of the FASTQ passed for that orientation. On mismatch it prints a `[merge-pairs] warning:` to stderr and **proceeds** (a warning, not a hard error). Older JSONs lacking the field are skipped — same graceful-degradation pattern as the existing `sample`/`map` fields.

This records the *file*, not the user-chosen sample label, so it is immune to custom sample names and needs no F/R-token heuristic.

## Testing
- `cargo build`/`clippy`/`fmt` clean; full suite passes (47 + 12).
- Updated `dada_from_fastq_matches_dada_from_derep_json` to ignore `input_file`, which legitimately differs between FASTQ-sourced and JSON-sourced runs; the denoising-equivalence invariant it tests is unchanged.
- Smoke-tested end-to-end: correct pairing → no warning; swapped reverse FASTQ → warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)