### PR TITLE
Experimental WFA alignment backend (wfa2lib-rs), opt-in via --align-backend (#49)

### DIFF
--- a/.github/workflows/concordance.yml
+++ b/.github/workflows/concordance.yml
@@ -77,6 +77,31 @@ jobs:
               --min-count-corr "$MIN_COUNT_CORR" --gate \
               --summary "$GITHUB_STEP_SUMMARY" --json work/illumina_report.json
 
+      # -------- Illumina with the experimental WFA backend (issue #49) ---------
+      # Same fixtures + same R reference + same gate, but the whole pipeline
+      # (learn-errors, dada, remove-bimera-denovo) runs with --align-backend
+      # wfa2. WFA is ASV-equivalent to NW on this data, so it must clear the
+      # same thresholds; this guards against the WFA path regressing.
+      - name: Illumina (WFA) — run dada2-rs pipeline
+        run: |
+          ALIGN_BACKEND=wfa2 bash dev/concordance/run_illumina.sh \
+              ./target/release/dada2-rs \
+              dev/concordance/data/illumina work/illumina_wfa 2
+
+      - name: Illumina (WFA) — compare to R reference
+        run: |
+          ref=dev/concordance/reference/illumina_seqtab_nochim.csv
+          if [ ! -f "$ref" ]; then
+            echo "::notice::Illumina reference CSV not committed yet ($ref); skipping WFA comparison."
+            exit 0
+          fi
+          python3 dev/concordance/compare_to_reference.py \
+              --rs work/illumina_wfa/seqtab.nochim.json --reference "$ref" \
+              --label illumina-wfa --min-abundance "$MIN_ABUNDANCE" \
+              --min-recall "$MIN_RECALL" --min-precision "$MIN_PRECISION" \
+              --min-count-corr "$MIN_COUNT_CORR" --gate \
+              --summary "$GITHUB_STEP_SUMMARY" --json work/illumina_wfa_report.json
+
       # ---------------- PacBio (committed subsampled fixture) -----------------
       # Skipped until both the fixture and the reference CSV are committed.
       - name: PacBio — run + compare (if fixture present)
@@ -115,6 +140,32 @@ jobs:
               --min-recall "$MIN_RECALL" --min-precision "$MIN_PRECISION" \
               --min-count-corr "$MIN_COUNT_CORR" --gate \
               --summary "$GITHUB_STEP_SUMMARY" --json work/pacbio_k7_report.json
+
+      # -------- PacBio with the experimental WFA backend (issue #49) ----------
+      # HiFi uses no homopolymer setting, so WFA is a full swap here. k=5 to
+      # match R's fixed KMER_SIZE / the reference. Guarded on the fixture like
+      # the NW PacBio step above.
+      - name: PacBio (WFA) — run + compare (if fixture present)
+        run: |
+          data=dev/concordance/data/pacbio
+          ref=dev/concordance/reference/pacbio_seqtab_nochim.csv
+          if [ ! -d "$data" ] || [ -z "$(ls -A "$data"/*.fastq.gz 2>/dev/null)" ]; then
+            echo "::notice::PacBio fixture not committed yet ($data); skipping WFA run."
+            exit 0
+          fi
+          ALIGN_BACKEND=wfa2 bash dev/concordance/run_pacbio.sh \
+              ./target/release/dada2-rs "$data" work/pacbio_wfa \
+              AGRGTTYGATYMTGGCTCAG RGYTACCTTGTTACGACTT 2
+          if [ ! -f "$ref" ]; then
+            echo "::notice::PacBio reference CSV not committed yet ($ref); WFA pipeline ran, no comparison."
+            exit 0
+          fi
+          python3 dev/concordance/compare_to_reference.py \
+              --rs work/pacbio_wfa/seqtab.nochim.json --reference "$ref" \
+              --label pacbio-wfa --min-abundance "$MIN_ABUNDANCE" \
+              --min-recall "$MIN_RECALL" --min-precision "$MIN_PRECISION" \
+              --min-count-corr "$MIN_COUNT_CORR" --gate \
+              --summary "$GITHUB_STEP_SUMMARY" --json work/pacbio_wfa_report.json
 
       - name: Upload reports
         if: always()

--- a/.github/workflows/concordance.yml
+++ b/.github/workflows/concordance.yml
@@ -141,31 +141,11 @@ jobs:
               --min-count-corr "$MIN_COUNT_CORR" --gate \
               --summary "$GITHUB_STEP_SUMMARY" --json work/pacbio_k7_report.json
 
-      # -------- PacBio with the experimental WFA backend (issue #49) ----------
-      # HiFi uses no homopolymer setting, so WFA is a full swap here. k=5 to
-      # match R's fixed KMER_SIZE / the reference. Guarded on the fixture like
-      # the NW PacBio step above.
-      - name: PacBio (WFA) — run + compare (if fixture present)
-        run: |
-          data=dev/concordance/data/pacbio
-          ref=dev/concordance/reference/pacbio_seqtab_nochim.csv
-          if [ ! -d "$data" ] || [ -z "$(ls -A "$data"/*.fastq.gz 2>/dev/null)" ]; then
-            echo "::notice::PacBio fixture not committed yet ($data); skipping WFA run."
-            exit 0
-          fi
-          ALIGN_BACKEND=wfa2 bash dev/concordance/run_pacbio.sh \
-              ./target/release/dada2-rs "$data" work/pacbio_wfa \
-              AGRGTTYGATYMTGGCTCAG RGYTACCTTGTTACGACTT 2
-          if [ ! -f "$ref" ]; then
-            echo "::notice::PacBio reference CSV not committed yet ($ref); WFA pipeline ran, no comparison."
-            exit 0
-          fi
-          python3 dev/concordance/compare_to_reference.py \
-              --rs work/pacbio_wfa/seqtab.nochim.json --reference "$ref" \
-              --label pacbio-wfa --min-abundance "$MIN_ABUNDANCE" \
-              --min-recall "$MIN_RECALL" --min-precision "$MIN_PRECISION" \
-              --min-count-corr "$MIN_COUNT_CORR" --gate \
-              --summary "$GITHUB_STEP_SUMMARY" --json work/pacbio_wfa_report.json
+      # NOTE: a PacBio WFA-backend concordance step is deliberately NOT added yet.
+      # The WFA adapter allocates a fresh aligner per call, which makes PacBio
+      # learn-errors (many ~1500 bp alignments) >13x slower than the NW path
+      # (>6 min vs ~28s locally) — impractical for CI. Re-add once the aligner is
+      # cached in AlignBuffers (issue #49). WFA stays experimental until then.
 
       - name: Upload reports
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ notes/Chat*
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Local-only cargo override (points wfa2lib-rs at a local fork checkout; must
+# not reach CI, where that path does not exist). See .cargo/config.toml.
+/.cargo/config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "statrs",
+ "wfa2lib-rs",
 ]
 
 [[package]]
@@ -307,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +324,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "matrixmultiply"
@@ -427,6 +440,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +514,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "ppv-lite86"
@@ -644,6 +678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "simba"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +704,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "statrs"
@@ -692,6 +741,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +825,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +841,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wfa2lib-rs"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "wide"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 [[package]]
 name = "wfa2lib-rs"
 version = "0.1.0"
+source = "git+https://github.com/HPCBio/wfa2lib-rs?rev=4cfeda86a3e1#4cfeda86a3e1e14e332c82e80e1dbe103c239b12"
 dependencies = [
  "clap",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ sha1 = "0.10"
 libc = "0.2"
 # Pure-Rust WFA aligner (experimental backend, feat/wfa-backend). default-features
 # = false avoids its `mimalloc-alloc` default, which would install a global
-# allocator into this crate. Local path while the HPCBio fork is iterated; pin to
-# a git rev before merge.
-wfa2lib-rs = { path = "/Users/cjfields/src/wfa2lib-rs", default-features = false }
+# allocator into this crate. Pinned to a SHA on the public HPCBio fork so CI can
+# fetch it; for local fork iteration uncomment the [patch] override below.
+wfa2lib-rs = { git = "https://github.com/HPCBio/wfa2lib-rs", rev = "4cfeda86a3e1", default-features = false }
 
 [dev-dependencies]
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,9 @@
 name = "dada2-rs"
 version = "0.1.1"
 edition = "2024"
-rust-version = "1.87"
+# Raised from 1.87 to 1.91 by the experimental WFA backend (wfa2lib-rs MSRV).
+# Revisit if the WFA backend is dropped.
+rust-version = "1.91"
 license = "LGPL-3.0-only"
 description = "An experimental Rust implementation of the DADA2 amplicon denoising algorithm"
 repository = "https://github.com/HPCBio/dada2-rs"
@@ -24,6 +26,11 @@ rand = { version = "0.8", features = ["small_rng"] }
 md-5 = "0.10"
 sha1 = "0.10"
 libc = "0.2"
+# Pure-Rust WFA aligner (experimental backend, feat/wfa-backend). default-features
+# = false avoids its `mimalloc-alloc` default, which would install a global
+# allocator into this crate. Local path while the HPCBio fork is iterated; pin to
+# a git rev before merge.
+wfa2lib-rs = { path = "/Users/cjfields/src/wfa2lib-rs", default-features = false }
 
 [dev-dependencies]
 serde_json = "1"

--- a/dev/concordance/run_illumina.sh
+++ b/dev/concordance/run_illumina.sh
@@ -17,6 +17,15 @@ DATA="${2:?missing data-dir}"
 OUT="${3:?missing out-dir}"
 THREADS="${4:-2}"
 
+# Optional alignment backend (nw|wfa2). When set, it is threaded through every
+# alignment-using subcommand (learn-errors, dada, remove-bimera-denovo) so the
+# concordance guardrail can run the whole pipeline with WFA. Unset = default
+# (nw), leaving existing behavior unchanged. The `+"${...}"` form keeps the
+# empty-array expansion safe under `set -u`.
+ALIGN_BACKEND="${ALIGN_BACKEND:-}"
+backend_arg=()
+[ -n "$ALIGN_BACKEND" ] && backend_arg=(--align-backend "$ALIGN_BACKEND")
+
 # --- Parameters (keep in sync with write_reference.R) ---
 TRUNC_LEN_F=240
 TRUNC_LEN_R=160
@@ -50,16 +59,16 @@ done
 
 echo "==> learn-errors (fwd, rev)"
 "$BIN" learn-errors "${filtFs[@]}" --nbases "$NBASES" --errfun loess \
-    --threads "$THREADS" -o "$OUT/errF.json"
+    --threads "$THREADS" ${backend_arg[@]+"${backend_arg[@]}"} -o "$OUT/errF.json"
 "$BIN" learn-errors "${filtRs[@]}" --nbases "$NBASES" --errfun loess \
-    --threads "$THREADS" -o "$OUT/errR.json"
+    --threads "$THREADS" ${backend_arg[@]+"${backend_arg[@]}"} -o "$OUT/errR.json"
 
 # Per-sample denoising (pool=FALSE analog) — matches R dada() default.
 echo "==> dada (fwd, rev; per-sample)"
 "$BIN" dada "${filtFs[@]}" --error-model "$OUT/errF.json" \
-    --output-dir "$OUT/dada_fwd" --threads "$THREADS"
+    --output-dir "$OUT/dada_fwd" --threads "$THREADS" ${backend_arg[@]+"${backend_arg[@]}"}
 "$BIN" dada "${filtRs[@]}" --error-model "$OUT/errR.json" \
-    --output-dir "$OUT/dada_rev" --threads "$THREADS"
+    --output-dir "$OUT/dada_rev" --threads "$THREADS" ${backend_arg[@]+"${backend_arg[@]}"}
 
 echo "==> merge-pairs"
 "$BIN" merge-pairs \
@@ -72,6 +81,6 @@ echo "==> make-sequence-table"
 
 echo "==> remove-bimera-denovo"
 "$BIN" remove-bimera-denovo "$OUT/seqtab.json" --method consensus \
-    --threads "$THREADS" -o "$OUT/seqtab.nochim.json"
+    --threads "$THREADS" ${backend_arg[@]+"${backend_arg[@]}"} -o "$OUT/seqtab.nochim.json"
 
 echo "==> done: $OUT/seqtab.nochim.json"

--- a/dev/concordance/run_pacbio.sh
+++ b/dev/concordance/run_pacbio.sh
@@ -21,6 +21,14 @@ PRIMER_FWD="${4:?missing primer_fwd}"
 PRIMER_REV="${5:?missing primer_rev}"
 THREADS="${6:-2}"
 
+# Optional alignment backend (nw|wfa2), threaded through the alignment-using
+# subcommands (learn-errors, dada, remove-bimera-denovo) so the concordance
+# guardrail can run the pipeline with WFA. Unset = default (nw). The
+# `+"${...}"` form keeps empty-array expansion safe under `set -u`.
+ALIGN_BACKEND="${ALIGN_BACKEND:-}"
+backend_arg=()
+[ -n "$ALIGN_BACKEND" ] && backend_arg=(--align-backend "$ALIGN_BACKEND")
+
 # --- Parameters (keep in sync with write_reference.R pacbio branch) ---
 MIN_LEN=1000
 MAX_LEN=1600
@@ -60,17 +68,19 @@ done
 
 echo "==> learn-errors (pacbio errfun, k=$KMER)"
 "$BIN" learn-errors "${filts[@]}" --nbases "$NBASES" --errfun pacbio \
-    --band "$BAND" --kmer-size "$KMER" --threads "$THREADS" -o "$OUT/err.json"
+    --band "$BAND" --kmer-size "$KMER" --threads "$THREADS" \
+    ${backend_arg[@]+"${backend_arg[@]}"} -o "$OUT/err.json"
 
 echo "==> dada (per-sample)"
 "$BIN" dada "${filts[@]}" --error-model "$OUT/err.json" \
-    --output-dir "$OUT/dada" --band "$BAND" --kmer-size "$KMER" --threads "$THREADS"
+    --output-dir "$OUT/dada" --band "$BAND" --kmer-size "$KMER" --threads "$THREADS" \
+    ${backend_arg[@]+"${backend_arg[@]}"}
 
 echo "==> make-sequence-table"
 "$BIN" make-sequence-table "$OUT"/dada/*.json -o "$OUT/seqtab.json"
 
 echo "==> remove-bimera-denovo"
 "$BIN" remove-bimera-denovo "$OUT/seqtab.json" --method consensus \
-    --threads "$THREADS" -o "$OUT/seqtab.nochim.json"
+    --threads "$THREADS" ${backend_arg[@]+"${backend_arg[@]}"} -o "$OUT/seqtab.nochim.json"
 
 echo "==> done: $OUT/seqtab.nochim.json"

--- a/src/chimera.rs
+++ b/src/chimera.rs
@@ -9,7 +9,34 @@
 
 use rayon::prelude::*;
 
-use crate::nwalign::{AlignBuffers, VectorizedAlignScores, align_vectorized_with_buf};
+use crate::nwalign::{
+    AlignBackend, AlignBuffers, VectorizedAlignScores, align_vectorized_with_buf,
+    align_wfa_endsfree_with_buf,
+};
+
+/// Align `sq` against `par` (ends-free) into `buf`, dispatching on `backend`.
+/// `Nw` uses the vectorized NW; `Wfa2` the experimental WFA backend. WFA takes
+/// `i32` scores, so the `i16` `VectorizedAlignScores` are widened.
+#[inline]
+fn bimera_align(
+    sq: &[u8],
+    par: &[u8],
+    scores: &VectorizedAlignScores,
+    backend: AlignBackend,
+    buf: &mut AlignBuffers,
+) {
+    match backend {
+        AlignBackend::Nw => align_vectorized_with_buf(sq, par, scores, buf),
+        AlignBackend::Wfa2 => align_wfa_endsfree_with_buf(
+            sq,
+            par,
+            scores.match_score as i32,
+            scores.mismatch as i32,
+            scores.gap_p as i32,
+            buf,
+        ),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Private alignment helpers
@@ -157,6 +184,9 @@ pub struct BimeraAlignParams {
     pub mismatch: i16,
     pub gap_p: i16,
     pub max_shift: i32,
+    /// Pairwise-alignment backend (issue #49). `Nw` uses the vectorized NW;
+    /// `Wfa2` routes through the experimental WFA backend.
+    pub backend: AlignBackend,
 }
 
 /// Determine whether `sq` is a bimera of any pair from `parents`.
@@ -192,6 +222,7 @@ pub fn is_bimera_with_buf(
         mismatch,
         gap_p,
         max_shift,
+        backend,
     } = *params;
     let align_scores = VectorizedAlignScores {
         match_score,
@@ -209,7 +240,7 @@ pub fn is_bimera_with_buf(
     let mut oo_max_right_oo = 0usize;
 
     for &par in parents {
-        align_vectorized_with_buf(sq, par, &align_scores, buf);
+        bimera_align(sq, par, &align_scores, backend, buf);
         let (al0, al1) = buf.alignment();
         let (left, right, left_oo, right_oo) = get_lr(al0, al1, allow_one_off, max_shift as usize);
 
@@ -291,6 +322,7 @@ pub fn table_bimera2(
         mismatch,
         gap_p,
         max_shift,
+        backend,
     } = *params;
     let align_scores = VectorizedAlignScores {
         match_score,
@@ -337,7 +369,7 @@ pub fn table_bimera2(
 
                     // Compute alignment if not cached for this (j, k) pair.
                     if cache[k].is_none() {
-                        align_vectorized_with_buf(seqs[j], seqs[k], &align_scores, buf);
+                        bimera_align(seqs[j], seqs[k], &align_scores, backend, buf);
                         let (al0, al1) = buf.alignment();
                         let (left, right, left_oo, right_oo) =
                             get_lr(al0, al1, allow_one_off, max_shift as usize);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use clap::{ArgAction, Parser, Subcommand};
 
 use crate::misc::DADA2_RS_VERSION;
+use crate::nwalign::AlignBackend;
 
 #[derive(Parser)]
 #[command(
@@ -247,6 +248,12 @@ pub enum Commands {
         #[arg(long, allow_hyphen_values = true)]
         mismatch: Option<i32>,
 
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend (wfa2lib-rs) — ASV-equivalent on tested
+        /// Illumina and PacBio HiFi data, but alignments are not byte-identical.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
+
         /// Maximum number of clusters to infer (R's MAX_CLUST). 0 = unlimited.
         #[arg(long)]
         max_clust: Option<usize>,
@@ -432,6 +439,12 @@ pub enum Commands {
         #[arg(long, allow_hyphen_values = true)]
         mismatch: Option<i32>,
 
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend (wfa2lib-rs) — ASV-equivalent on tested
+        /// Illumina and PacBio HiFi data, but alignments are not byte-identical.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
+
         /// Maximum number of clusters to infer (R's MAX_CLUST). 0 = unlimited.
         #[arg(long)]
         max_clust: Option<usize>,
@@ -596,6 +609,12 @@ pub enum Commands {
         /// Mismatch score for the Needleman-Wunsch alignment (R's MISMATCH).
         #[arg(long, allow_hyphen_values = true)]
         mismatch: Option<i32>,
+
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend (wfa2lib-rs) — ASV-equivalent on tested
+        /// Illumina and PacBio HiFi data, but alignments are not byte-identical.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
 
         /// Maximum number of clusters to infer (R's MAX_CLUST). 0 = unlimited.
         #[arg(long)]
@@ -1083,6 +1102,12 @@ pub enum Commands {
         #[arg(long, allow_hyphen_values = true, default_value_t = -8)]
         gap_p: i16,
 
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend (wfa2lib-rs) — ASV-equivalent on tested
+        /// Illumina and PacBio HiFi data, but alignments are not byte-identical.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
+
         /// (consensus) Fraction of samples a sequence must be flagged in
         #[arg(long, default_value_t = 0.9)]
         min_sample_fraction: f64,
@@ -1521,6 +1546,12 @@ pub enum Commands {
         #[arg(long, default_value_t = -4, allow_hyphen_values = true)]
         mismatch: i32,
 
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend (wfa2lib-rs) — ASV-equivalent on tested
+        /// Illumina and PacBio HiFi data, but alignments are not byte-identical.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
+
         /// Maximum number of clusters to infer (R's MAX_CLUST). 0 = unlimited.
         #[arg(long, default_value_t = 0)]
         max_clust: usize,
@@ -1789,6 +1820,12 @@ pub enum Commands {
         /// Mismatch score for the Needleman-Wunsch alignment (R's MISMATCH).
         #[arg(long, default_value_t = -4, allow_hyphen_values = true)]
         mismatch: i32,
+
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend (wfa2lib-rs) — ASV-equivalent on tested
+        /// Illumina and PacBio HiFi data, but alignments are not byte-identical.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
 
         /// Maximum number of clusters to infer (R's MAX_CLUST). 0 = unlimited.
         #[arg(long, default_value_t = 0)]

--- a/src/learn_errors.rs
+++ b/src/learn_errors.rs
@@ -200,6 +200,10 @@ pub struct LearnedErrParams {
     pub vectorized: bool,
     #[serde(default)]
     pub gapless: bool,
+    /// Pairwise-alignment backend the model was learned with (issue #49).
+    /// Defaults to `nw` for JSONs produced before this field existed.
+    #[serde(default)]
+    pub backend: crate::nwalign::AlignBackend,
 
     /// Loess configuration captured from the errfun. Present for errfuns that
     /// use loess fitting (`loess`, `noqual`, `binned-qual`, `pacbio`); absent

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ use learn_errors::{
     load_fastq_samples,
 };
 use misc::{DADA2_RS_VERSION, Tagged, read_fasta_records, read_tagged_json};
-use nwalign::AlignParams;
+use nwalign::{AlignBackend, AlignParams};
 use remove_bimera::{BimeraParams, Method, remove_bimera_denovo};
 use remove_primers::{RemovePrimersParams, iupac_reverse_complement, remove_primers};
 use sequence_table::{HashAlgo, OrderBy, SequenceTable, make_sequence_table};
@@ -144,6 +144,7 @@ fn build_learned_err_params(
         band: ap.band,
         vectorized: ap.vectorized,
         gapless: ap.gapless,
+        backend: ap.backend,
     }
 }
 
@@ -427,6 +428,7 @@ fn main() -> io::Result<()> {
             gap_p,
             match_score,
             mismatch,
+            align_backend,
             max_clust,
             greedy,
             use_quals,
@@ -528,6 +530,7 @@ fn main() -> io::Result<()> {
                     kdist_cutoff,
                     kmer_size,
                     no_kmer_screen,
+                    align_backend,
                 )?;
 
                 // Samples are independent and single-pass (load -> denoise ->
@@ -681,6 +684,7 @@ fn main() -> io::Result<()> {
                 kdist_cutoff,
                 kmer_size,
                 no_kmer_screen,
+                align_backend,
             )?;
             let dada_params = resolved.params;
             let run_params = resolved.run;
@@ -890,6 +894,7 @@ fn main() -> io::Result<()> {
             gap_p,
             match_score,
             mismatch,
+            align_backend,
             max_clust,
             greedy,
             use_quals,
@@ -1107,6 +1112,7 @@ fn main() -> io::Result<()> {
                 kdist_cutoff,
                 kmer_size,
                 no_kmer_screen,
+                align_backend,
             )?;
             let dada_params = resolved.params;
             let mut run_params = resolved.run;
@@ -1257,6 +1263,7 @@ fn main() -> io::Result<()> {
             gap_p,
             match_score,
             mismatch,
+            align_backend,
             max_clust,
             greedy,
             use_quals,
@@ -1331,6 +1338,7 @@ fn main() -> io::Result<()> {
                 kdist_cutoff,
                 kmer_size,
                 no_kmer_screen,
+                align_backend,
             )?;
 
             // ---- Round 1: denoise each sample independently (no priors) ----
@@ -2078,6 +2086,7 @@ fn main() -> io::Result<()> {
             match_score,
             mismatch,
             gap_p,
+            align_backend,
             min_sample_fraction,
             ignore_n_negatives,
             threads,
@@ -2105,6 +2114,7 @@ fn main() -> io::Result<()> {
                 match_score,
                 mismatch,
                 gap_p,
+                backend: align_backend.unwrap_or_default(),
             };
 
             let pool = rayon::ThreadPoolBuilder::new()
@@ -2429,6 +2439,7 @@ fn main() -> io::Result<()> {
             gap_p,
             match_score,
             mismatch,
+            align_backend,
             max_clust,
             greedy,
             use_quals,
@@ -2514,6 +2525,7 @@ fn main() -> io::Result<()> {
             };
 
             let align_params = AlignParams {
+                backend: align_backend.unwrap_or_default(),
                 match_score,
                 mismatch,
                 gap_p,
@@ -3103,6 +3115,7 @@ fn main() -> io::Result<()> {
             gap_p,
             match_score,
             mismatch,
+            align_backend,
             max_clust,
             greedy,
             use_quals,
@@ -3188,6 +3201,7 @@ fn main() -> io::Result<()> {
             };
 
             let align_params = AlignParams {
+                backend: align_backend.unwrap_or_default(),
                 match_score,
                 mismatch,
                 gap_p,
@@ -3491,6 +3505,7 @@ fn resolve_dada_params(
     kdist_cutoff: Option<f64>,
     kmer_size: Option<usize>,
     no_kmer_screen: Option<bool>,
+    align_backend: Option<AlignBackend>,
 ) -> io::Result<ResolvedDada> {
     let em: ErrorModelJson = read_tagged_json(error_model, &["learn-errors", "errors-from-sample"])
         .with_path(error_model)?;
@@ -3560,6 +3575,7 @@ fn resolve_dada_params(
         (None, true, Some(em_params)) => em_params.use_kmers,
         _ => true,
     };
+    let backend = resolve!(align_backend, backend, AlignBackend::Nw);
 
     // ---- Consistency warnings (only when NOT inheriting) ----
     if !inherit_err_params && let Some(em_params) = p {
@@ -3590,6 +3606,7 @@ fn resolve_dada_params(
         check!("kdist_cutoff", kdist_cutoff, em_params.kdist_cutoff);
         check!("kmer_size", kmer_size, em_params.kmer_size);
         check!("use_kmers", use_kmers, em_params.use_kmers);
+        check!("align_backend", backend, em_params.backend);
         if !mismatches.is_empty() {
             eprintln!(
                 "[dada] warning: {} dada parameter(s) differ from error model {}; pass --inherit-err-params to adopt the err model's values:",
@@ -3603,6 +3620,7 @@ fn resolve_dada_params(
     }
 
     let align_params = AlignParams {
+        backend,
         match_score,
         mismatch,
         gap_p,

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -1567,6 +1567,82 @@ mod tests {
         compare_wfa(&s1, &s2, "diff-len-short");
     }
 
+    /// Isolation experiment: compare WFA *global* (`align_end2end`) against the
+    /// scalar *global* `align_standard` (both linear gap, penalized ends). If
+    /// these agree where ends-free diverges, the divergence is purely in
+    /// ends-free free-end-gap crediting, not the interior gap model — meaning
+    /// affine gap scoring would not address it.
+    ///   cargo test --release --bins wfa_global_isolation -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn wfa_global_isolation() {
+        use wfa2lib_rs::aligner::{AffineAligner, AlignmentScope};
+        use wfa2lib_rs::penalties::{AffinePenalties, WavefrontPenalties};
+
+        fn wfa_global(s1: &[u8], s2: &[u8]) -> [Vec<u8>; 2] {
+            let penalties = WavefrontPenalties::new_affine(AffinePenalties {
+                match_: -5,
+                mismatch: 4,
+                gap_opening: 0,
+                gap_extension: 8,
+            });
+            let mut a = AffineAligner::new(penalties);
+            a.alignment_scope = AlignmentScope::ComputeAlignment;
+            a.align_end2end(s1, s2);
+            let mut al0 = Vec::new();
+            let mut al1 = Vec::new();
+            cigar_to_alignment_into(a.cigar().operations_slice(), s1, s2, &mut al0, &mut al1);
+            [al0, al1]
+        }
+
+        let nts = [1u8, 2, 3, 4];
+        let mut st: u64 = 0xDEAD_BEEF_0BAD_F00D;
+        let mut rng = |st: &mut u64, m: usize| {
+            *st = st.wrapping_mul(6364136223846793005).wrapping_add(1);
+            ((*st >> 33) as usize) % m
+        };
+        let mut global_fails = 0u32;
+        let mut endsfree_fails = 0u32;
+        let n = 10_000;
+        for _ in 0..n {
+            let len = 40 + rng(&mut st, 60);
+            let s1: Vec<u8> = (0..len).map(|_| nts[rng(&mut st, 4)]).collect();
+            let mut s2 = s1.clone();
+            for _ in 0..rng(&mut st, 6) {
+                if s2.is_empty() {
+                    break;
+                }
+                let p = rng(&mut st, s2.len());
+                match rng(&mut st, 3) {
+                    0 => s2[p] = nts[rng(&mut st, 4)],
+                    1 => s2.insert(p, nts[rng(&mut st, 4)]),
+                    _ => {
+                        s2.remove(p);
+                    }
+                }
+            }
+            if s2.len() < 3 {
+                continue;
+            }
+            // Global: WFA end2end vs scalar align_standard (band=-1, unbanded).
+            let g_scalar = align_standard(&s1, &s2, 5, -4, -8, -1);
+            let g_wfa = wfa_global(&s1, &s2);
+            if score_alignment(&g_scalar, 5, -4, -8) != score_alignment(&g_wfa, 5, -4, -8) {
+                global_fails += 1;
+            }
+            // Ends-free: WFA endsfree vs scalar align_endsfree, for comparison.
+            let e_scalar = align_endsfree(&s1, &s2, 5, -4, -8, -1);
+            let mut buf = AlignBuffers::new();
+            align_wfa_endsfree_with_buf(&s1, &s2, 5, -4, -8, &mut buf);
+            let e_wfa = [buf.al0.clone(), buf.al1.clone()];
+            if score_alignment(&e_scalar, 5, -4, -8) != score_alignment(&e_wfa, 5, -4, -8) {
+                endsfree_fails += 1;
+            }
+        }
+        println!("  WFA global   vs align_standard : {global_fails}/{n} disagree");
+        println!("  WFA endsfree vs align_endsfree : {endsfree_fails}/{n} disagree");
+    }
+
     /// Find and print the first few low-edit pairs where WFA disagrees with
     /// `align_endsfree`, with both alignments, to diagnose the cause.
     ///   cargo test --release --bins wfa_diagnose -- --ignored --nocapture

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -25,9 +25,37 @@ const BAND_SENTINEL: i32 = -9999;
 // AlignParams
 // ---------------------------------------------------------------------------
 
+/// Pairwise-alignment backend (issue #49).
+///
+/// `Nw` is the default scalar/vectorized Needleman-Wunsch path. `Wfa2` routes
+/// the ends-free path through the experimental WFA backend (wfa2lib-rs). WFA is
+/// ASV-equivalent to NW on tested Illumina and PacBio HiFi data but its
+/// alignments are not byte-identical (see `sweep_wfa_parity`).
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum AlignBackend {
+    /// Needleman-Wunsch (scalar/vectorized), the default.
+    #[default]
+    Nw,
+    /// Experimental wavefront alignment via wfa2lib-rs.
+    Wfa2,
+}
+
 /// Parameters controlling alignment method selection in `raw_align`.
 #[derive(Clone, Copy)]
 pub struct AlignParams {
+    /// Which pairwise-alignment backend to use for the ends-free path.
+    pub backend: AlignBackend,
     pub match_score: i32,
     pub mismatch: i32,
     pub gap_p: i32,
@@ -1276,13 +1304,13 @@ pub fn raw_align_with_buf(
     // Without this, a `--homo-gap-p` setting would be silently ignored by the
     // vectorized path and diverge from R.
     let use_homo = p.homo_gap_p != p.gap_p && p.homo_gap_p <= 0;
-    // Experimental WFA backend (issue #49), opt-in via DADA2RS_ALIGN_BACKEND=wfa.
-    // Replaces only the vectorized/ends-free scalar path; the gapless fast-path
-    // (above) and the homopolymer-aware path (below) are left untouched so an A/B
-    // run isolates the WFA aligner. NOTE: WFA ends-free is not yet byte-identical
-    // to align_endsfree (see sweep_wfa_parity); this flag exists to measure
-    // end-to-end ASV impact on real data, not for production use.
-    if *USE_WFA_BACKEND && !use_homo {
+    // Experimental WFA backend (issue #49), selected via `p.backend` (CLI
+    // `--align-backend wfa2`) or the undocumented `DADA2RS_ALIGN_BACKEND=wfa`
+    // override (handy for sweeps). Replaces only the vectorized/ends-free path;
+    // the gapless fast-path (above) and the homopolymer-aware path (below) are
+    // left untouched. NOTE: WFA ends-free is not byte-identical to align_endsfree
+    // (see sweep_wfa_parity), though it is ASV-equivalent on tested data.
+    if (p.backend == AlignBackend::Wfa2 || *USE_WFA_BACKEND) && !use_homo {
         align_wfa_endsfree_with_buf(
             &raw1.seq,
             &raw2.seq,
@@ -1959,6 +1987,7 @@ mod tests {
         let s2 = encode("AAAAAGGGGTTTAAAAAATTTTTCCCC");
 
         let params = AlignParams {
+            backend: AlignBackend::Nw,
             match_score: 5,
             mismatch: -4,
             gap_p: -8,

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -1043,8 +1043,18 @@ pub fn align_vectorized_with_buf(
 // byte equality and its EOS sentinels (`b'!'`=33, `b'?'`=63) never collide with
 // 1..=5, so no ASCII round-trip is needed.
 
+use std::sync::LazyLock;
 use wfa2lib_rs::aligner::{AffineAligner, AlignmentScope};
 use wfa2lib_rs::penalties::{AffinePenalties, WavefrontPenalties};
+
+/// Opt-in switch for the experimental WFA alignment backend (issue #49).
+/// Set `DADA2RS_ALIGN_BACKEND=wfa` to route the ends-free path through WFA.
+/// Read once at first alignment.
+static USE_WFA_BACKEND: LazyLock<bool> = LazyLock::new(|| {
+    std::env::var("DADA2RS_ALIGN_BACKEND")
+        .map(|v| v.eq_ignore_ascii_case("wfa"))
+        .unwrap_or(false)
+});
 
 /// Convert a WFA CIGAR (`M`/`X`/`I`/`D` ops, pattern=s1, text=s2) into the
 /// gap-annotated `[al0, al1]` pair the rest of the module consumes.
@@ -1266,6 +1276,23 @@ pub fn raw_align_with_buf(
     // Without this, a `--homo-gap-p` setting would be silently ignored by the
     // vectorized path and diverge from R.
     let use_homo = p.homo_gap_p != p.gap_p && p.homo_gap_p <= 0;
+    // Experimental WFA backend (issue #49), opt-in via DADA2RS_ALIGN_BACKEND=wfa.
+    // Replaces only the vectorized/ends-free scalar path; the gapless fast-path
+    // (above) and the homopolymer-aware path (below) are left untouched so an A/B
+    // run isolates the WFA aligner. NOTE: WFA ends-free is not yet byte-identical
+    // to align_endsfree (see sweep_wfa_parity); this flag exists to measure
+    // end-to-end ASV impact on real data, not for production use.
+    if *USE_WFA_BACKEND && !use_homo {
+        align_wfa_endsfree_with_buf(
+            &raw1.seq,
+            &raw2.seq,
+            p.match_score,
+            p.mismatch,
+            p.gap_p,
+            buf,
+        );
+        return Some(());
+    }
     // Long-read guard: align_vectorized uses i16 DP tables. With the default
     // DADA2 scoring (match=5, mismatch=-4, gap_p=-8) cumulative scores can
     // approach ±8·N, so we must fall back to the i32 path before overflow

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -1071,6 +1071,7 @@ pub fn align_vectorized_with_buf(
 // byte equality and its EOS sentinels (`b'!'`=33, `b'?'`=63) never collide with
 // 1..=5, so no ASCII round-trip is needed.
 
+use std::cell::RefCell;
 use std::sync::LazyLock;
 use wfa2lib_rs::aligner::{AffineAligner, AlignmentScope};
 use wfa2lib_rs::penalties::{AffinePenalties, WavefrontPenalties};
@@ -1138,27 +1139,47 @@ pub fn align_wfa_endsfree_with_buf(
     gap_p: i32,
     buf: &mut AlignBuffers,
 ) {
-    let penalties = WavefrontPenalties::new_affine(AffinePenalties {
-        match_: -match_score,
-        mismatch: -mismatch,
-        gap_opening: 0,
-        gap_extension: -gap_p,
+    // Reuse a per-thread aligner so wfa2lib-rs reaches its zero-alloc steady
+    // state instead of allocating a fresh aligner every call — the per-call
+    // allocation was >13× slower than NW on long PacBio reads. A `thread_local`
+    // (rather than a field on `AlignBuffers`) keeps the aligner off any struct
+    // that crosses threads: `WavefrontAligner` holds raw pointers (`!Send`),
+    // and `AlignBuffers` is carried in a rayon `fold` accumulator that must be
+    // `Send`. The aligner never moves between threads, so TLS is the right home.
+    // Rebuilt only when the scoring changes (constant within a run).
+    // (match, mismatch, gap_p) scoring key paired with the aligner built for it.
+    type WfaCache = ((i32, i32, i32), AffineAligner);
+    thread_local! {
+        static WFA: RefCell<Option<WfaCache>> = const { RefCell::new(None) };
+    }
+    WFA.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        let key = (match_score, mismatch, gap_p);
+        if slot.as_ref().map(|(k, _)| *k) != Some(key) {
+            let penalties = WavefrontPenalties::new_affine(AffinePenalties {
+                match_: -match_score,
+                mismatch: -mismatch,
+                gap_opening: 0,
+                gap_extension: -gap_p,
+            });
+            let mut aligner = AffineAligner::new(penalties);
+            // Compute the full CIGAR, not just the score (default ComputeScore
+            // leaves the cigar empty).
+            aligner.alignment_scope = AlignmentScope::ComputeAlignment;
+            *slot = Some((key, aligner));
+        }
+        let aligner = &mut slot.as_mut().unwrap().1;
+        // Full ends-free: leading/trailing gaps on either strand are free.
+        aligner.set_alignment_free_ends(
+            s1.len() as i32,
+            s1.len() as i32,
+            s2.len() as i32,
+            s2.len() as i32,
+        );
+        aligner.align_endsfree(s1, s2);
+        let ops = aligner.cigar().operations_slice();
+        cigar_to_alignment_into(ops, s1, s2, &mut buf.al0, &mut buf.al1);
     });
-    let mut aligner = AffineAligner::new(penalties);
-    // Compute the full CIGAR, not just the score (default is ComputeScore, which
-    // leaves the cigar empty). The field is pub; a public setter would be a good
-    // upstream addition.
-    aligner.alignment_scope = AlignmentScope::ComputeAlignment;
-    // Full ends-free: leading/trailing gaps on either strand are free.
-    aligner.set_alignment_free_ends(
-        s1.len() as i32,
-        s1.len() as i32,
-        s2.len() as i32,
-        s2.len() as i32,
-    );
-    aligner.align_endsfree(s1, s2);
-    let cigar = aligner.cigar();
-    cigar_to_alignment_into(cigar.operations_slice(), s1, s2, &mut buf.al0, &mut buf.al1);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -1025,6 +1025,105 @@ pub fn align_vectorized_with_buf(
 }
 
 // ---------------------------------------------------------------------------
+// WFA backend (experimental) — wavefront alignment via wfa2lib-rs
+// ---------------------------------------------------------------------------
+//
+// Wraps the pure-Rust WFA aligner (HPCBio fork of COMBINE-lab/wfa2lib-rs) so it
+// can stand in for `align_endsfree`. WFA *minimises a penalty* (cost) where the
+// match cost is ≤ 0, whereas DADA2 *maximises a score* (match = +5, mismatch =
+// −4, gap = −8). The two are equivalent under sign inversion (score → cost):
+//
+//     match_      = -match_score   (≤ 0, e.g. -5)
+//     mismatch    = -mismatch      (> 0, e.g.  4)
+//     gap_extension = -gap_p       (> 0, e.g.  8)   gap_opening = 0  (linear gap)
+//
+// wfa2lib-rs's `new_affine` applies the Eizenga adjustment internally when
+// `match_ < 0`, so a non-zero match score reproduces the same optimum as the
+// scalar DP. Sequences are passed as the raw 1..=5 nt encoding: WFA matches by
+// byte equality and its EOS sentinels (`b'!'`=33, `b'?'`=63) never collide with
+// 1..=5, so no ASCII round-trip is needed.
+
+use wfa2lib_rs::aligner::{AffineAligner, AlignmentScope};
+use wfa2lib_rs::penalties::{AffinePenalties, WavefrontPenalties};
+
+/// Convert a WFA CIGAR (`M`/`X`/`I`/`D` ops, pattern=s1, text=s2) into the
+/// gap-annotated `[al0, al1]` pair the rest of the module consumes.
+///
+/// Op semantics (from `Cigar::check_alignment`): `M`/`X` consume one base from
+/// each strand; `I` advances the text only (gap in pattern → `al0`); `D`
+/// advances the pattern only (gap in text → `al1`).
+#[allow(dead_code)]
+fn cigar_to_alignment_into(ops: &[u8], s1: &[u8], s2: &[u8], al0: &mut Vec<u8>, al1: &mut Vec<u8>) {
+    al0.clear();
+    al1.clear();
+    al0.reserve(ops.len());
+    al1.reserve(ops.len());
+    let mut p = 0usize; // pattern (s1) position
+    let mut t = 0usize; // text (s2) position
+    for &op in ops {
+        match op {
+            b'M' | b'X' => {
+                al0.push(s1[p]);
+                al1.push(s2[t]);
+                p += 1;
+                t += 1;
+            }
+            b'I' => {
+                al0.push(b'-');
+                al1.push(s2[t]);
+                t += 1;
+            }
+            b'D' => {
+                al0.push(s1[p]);
+                al1.push(b'-');
+                p += 1;
+            }
+            v => panic!("WFA cigar_to_alignment: unknown op {v} ({})", v as char),
+        }
+    }
+}
+
+/// Ends-free Needleman-Wunsch via the WFA backend. Fills `buf.al0`/`buf.al1`
+/// with the same alignment-pair representation as [`align_endsfree`].
+///
+/// `match_score`/`mismatch`/`gap_p` use the DADA2 score convention (match > 0,
+/// the rest < 0); they are converted to WFA penalties internally.
+///
+/// NOTE: constructs a fresh `AffineAligner` per call. The hot path will want a
+/// cached aligner in `AlignBuffers`; this is correctness-first.
+#[allow(dead_code)]
+pub fn align_wfa_endsfree_with_buf(
+    s1: &[u8],
+    s2: &[u8],
+    match_score: i32,
+    mismatch: i32,
+    gap_p: i32,
+    buf: &mut AlignBuffers,
+) {
+    let penalties = WavefrontPenalties::new_affine(AffinePenalties {
+        match_: -match_score,
+        mismatch: -mismatch,
+        gap_opening: 0,
+        gap_extension: -gap_p,
+    });
+    let mut aligner = AffineAligner::new(penalties);
+    // Compute the full CIGAR, not just the score (default is ComputeScore, which
+    // leaves the cigar empty). The field is pub; a public setter would be a good
+    // upstream addition.
+    aligner.alignment_scope = AlignmentScope::ComputeAlignment;
+    // Full ends-free: leading/trailing gaps on either strand are free.
+    aligner.set_alignment_free_ends(
+        s1.len() as i32,
+        s1.len() as i32,
+        s2.len() as i32,
+        s2.len() as i32,
+    );
+    aligner.align_endsfree(s1, s2);
+    let cigar = aligner.cigar();
+    cigar_to_alignment_into(cigar.operations_slice(), s1, s2, &mut buf.al0, &mut buf.al1);
+}
+
+// ---------------------------------------------------------------------------
 // Substitution compression
 // ---------------------------------------------------------------------------
 
@@ -1421,6 +1520,173 @@ mod tests {
                 "{label}: score mismatch: endsfree={score_ef} vectorized={score_ve}\n  EF: {ef0}\n      {ef1}\n  VE: {ve0}\n      {ve1}"
             );
         }
+    }
+
+    /// Assert the WFA backend produces the same optimal score as `align_endsfree`.
+    fn compare_wfa(s1: &[u8], s2: &[u8], label: &str) {
+        let ef = align_endsfree(s1, s2, MATCH, MM, GAP, BAND);
+        let mut buf = AlignBuffers::new();
+        align_wfa_endsfree_with_buf(s1, s2, MATCH, MM, GAP, &mut buf);
+        let wfa = [buf.al0.clone(), buf.al1.clone()];
+
+        let score_ef = score_alignment(&ef, MATCH, MM, GAP);
+        let score_wfa = score_alignment(&wfa, MATCH, MM, GAP);
+        if score_ef != score_wfa {
+            let (e0, e1) = decode_al(&ef);
+            let (w0, w1) = decode_al(&wfa);
+            panic!(
+                "{label}: WFA score mismatch: endsfree={score_ef} wfa={score_wfa}\n  EF: {e0}\n      {e1}\n  WFA: {w0}\n       {w1}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_wfa_vs_endsfree_identical() {
+        let s = encode("ACGTACGTACGT");
+        compare_wfa(&s, &s, "identical-short");
+    }
+
+    #[test]
+    fn test_wfa_vs_endsfree_one_sub() {
+        let s1 = encode("ACGTACGTACGT");
+        let s2 = encode("ACGTTCGTACGT");
+        compare_wfa(&s1, &s2, "one-sub");
+    }
+
+    #[test]
+    fn test_wfa_vs_endsfree_one_gap() {
+        let s1 = encode("ACGTACGTACGT");
+        let s2 = encode("ACGACGTACGT");
+        compare_wfa(&s1, &s2, "one-gap");
+    }
+
+    #[test]
+    fn test_wfa_vs_endsfree_different_lengths() {
+        let s1 = encode("ACGTACGTACGT");
+        let s2 = encode("ACGTACGTACGTAC");
+        compare_wfa(&s1, &s2, "diff-len-short");
+    }
+
+    /// Find and print the first few low-edit pairs where WFA disagrees with
+    /// `align_endsfree`, with both alignments, to diagnose the cause.
+    ///   cargo test --release --bins wfa_diagnose -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn wfa_diagnose() {
+        let nts = [1u8, 2, 3, 4];
+        let mut st: u64 = 0x1234_5678_9ABC_DEF0;
+        let mut rng = |st: &mut u64, m: usize| {
+            *st = st.wrapping_mul(6364136223846793005).wrapping_add(1);
+            ((*st >> 33) as usize) % m
+        };
+        let mut shown = 0;
+        for _ in 0..200_000 {
+            if shown >= 5 {
+                break;
+            }
+            let len = 40 + rng(&mut st, 60);
+            let s1: Vec<u8> = (0..len).map(|_| nts[rng(&mut st, 4)]).collect();
+            let mut s2 = s1.clone();
+            let nedits = 1 + rng(&mut st, 1);
+            for _ in 0..nedits {
+                let p = rng(&mut st, s2.len());
+                match rng(&mut st, 3) {
+                    0 => s2[p] = nts[rng(&mut st, 4)],
+                    1 => s2.insert(p, nts[rng(&mut st, 4)]),
+                    _ => {
+                        s2.remove(p);
+                    }
+                }
+            }
+            let ef = align_endsfree(&s1, &s2, 5, -4, -8, -1);
+            let mut buf = AlignBuffers::new();
+            align_wfa_endsfree_with_buf(&s1, &s2, 5, -4, -8, &mut buf);
+            let wfa = [buf.al0.clone(), buf.al1.clone()];
+            let sef = score_alignment(&ef, 5, -4, -8);
+            let swfa = score_alignment(&wfa, 5, -4, -8);
+            if sef != swfa {
+                let (e0, e1) = decode_al(&ef);
+                let (w0, w1) = decode_al(&wfa);
+                println!(
+                    "--- disagreement (edits={nedits}) ef={sef} wfa={swfa} len1={} len2={} ---",
+                    s1.len(),
+                    s2.len()
+                );
+                println!("EF : {e0}");
+                println!("     {e1}");
+                println!("WFA: {w0}");
+                println!("     {w1}");
+                shown += 1;
+            }
+        }
+    }
+
+    /// Randomized parity stress test: WFA must match `align_endsfree`'s optimal
+    /// score across many random pairs (varied lengths, indels). Run explicitly:
+    ///   cargo test --release -- --ignored sweep_wfa_parity --nocapture
+    #[test]
+    #[ignore]
+    fn sweep_wfa_parity() {
+        let nts = [1u8, 2, 3, 4];
+        let mut st: u64 = 0x1234_5678_9ABC_DEF0;
+        let mut rng = |st: &mut u64, m: usize| {
+            *st = st.wrapping_mul(6364136223846793005).wrapping_add(1);
+            ((*st >> 33) as usize) % m
+        };
+        // Bucket failures by number of edits to test the hypothesis that
+        // divergence (not a logic bug) drives disagreement. DADA2 only aligns
+        // k-mer-screened, very-similar pairs, so the low-edit buckets are the
+        // ones that matter.
+        let mut fails_by_edits = [0u32; 9];
+        let mut total_by_edits = [0u32; 9];
+        for _ in 0..10_000 {
+            let len = 40 + rng(&mut st, 210); // 40..250, amplicon-ish
+            let s1: Vec<u8> = (0..len).map(|_| nts[rng(&mut st, 4)]).collect();
+            let mut s2 = s1.clone();
+            let nedits = rng(&mut st, 9); // 0..8
+            for _ in 0..nedits {
+                if s2.is_empty() {
+                    break;
+                }
+                let p = rng(&mut st, s2.len());
+                match rng(&mut st, 3) {
+                    0 => s2[p] = nts[rng(&mut st, 4)],
+                    1 => s2.insert(p, nts[rng(&mut st, 4)]),
+                    _ => {
+                        s2.remove(p);
+                    }
+                }
+            }
+            if s2.len() < 3 {
+                continue;
+            }
+            let ef = align_endsfree(&s1, &s2, 5, -4, -8, -1);
+            let mut buf = AlignBuffers::new();
+            align_wfa_endsfree_with_buf(&s1, &s2, 5, -4, -8, &mut buf);
+            let wfa = [buf.al0.clone(), buf.al1.clone()];
+            total_by_edits[nedits] += 1;
+            if score_alignment(&ef, 5, -4, -8) != score_alignment(&wfa, 5, -4, -8) {
+                fails_by_edits[nedits] += 1;
+            }
+        }
+        for e in 0..9 {
+            println!(
+                "  edits={e}: {}/{} disagree",
+                fails_by_edits[e], total_by_edits[e]
+            );
+        }
+        // INFORMATIONAL (not asserted): documents the known divergence between
+        // the WFA backend and `align_endsfree`. WFA-via-Eizenga ends-free does
+        // not reproduce DADA2's exact score-maximizing optimum at gap/homopolymer
+        // boundaries and sequence ends (free end-gap crediting differs), so it is
+        // NOT yet a drop-in for align_endsfree. Tracked for the fork's ends-free
+        // handling. See wfa_diagnose for concrete counterexamples.
+        let low_edit_fails: u32 = fails_by_edits[..=4].iter().sum();
+        let total_fails: u32 = fails_by_edits.iter().sum();
+        println!(
+            "  TOTAL: {total_fails} disagree ({low_edit_fails} at <=4 edits) \
+             — known WFA ends-free divergence, see doc comment"
+        );
     }
 
     #[test]

--- a/src/remove_bimera.rs
+++ b/src/remove_bimera.rs
@@ -8,7 +8,7 @@
 use rayon::prelude::*;
 
 use crate::chimera::{BimeraAlignParams, is_bimera_with_buf, table_bimera2};
-use crate::nwalign::AlignBuffers;
+use crate::nwalign::{AlignBackend, AlignBuffers};
 use crate::sequence_table::SequenceTable;
 
 // ---------------------------------------------------------------------------
@@ -34,6 +34,8 @@ pub struct BimeraParams {
     pub match_score: i16,
     pub mismatch: i16,
     pub gap_p: i16,
+    /// Pairwise-alignment backend (issue #49).
+    pub backend: AlignBackend,
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +132,7 @@ fn consensus_flags(
         mismatch: p.mismatch,
         gap_p: p.gap_p,
         max_shift: p.max_shift,
+        backend: p.backend,
     };
     let flags = table_bimera2(
         mat,
@@ -173,6 +176,7 @@ fn pooled_flags(
         mismatch: p.mismatch,
         gap_p: p.gap_p,
         max_shift: p.max_shift,
+        backend: p.backend,
     };
 
     (0..ncol)
@@ -215,6 +219,7 @@ fn per_sample_cell_flags(
         mismatch: p.mismatch,
         gap_p: p.gap_p,
         max_shift: p.max_shift,
+        backend: p.backend,
     };
     let mut buf = AlignBuffers::new();
     (0..nrow)


### PR DESCRIPTION
Adds an **experimental** wavefront-alignment (WFA) backend as an opt-in alternative to the default Needleman-Wunsch aligner, wired end-to-end and gated by the concordance guardrail. Closes the exploratory part of #49.

## What this adds

- **WFA backend** via the pure-Rust [`wfa2lib-rs`](https://github.com/HPCBio/wfa2lib-rs) (no C/FFI). A CIGAR→`[al0, al1]` adapter feeds the existing `al2subs` → `pval.rs` pipeline, so the positional substitution contract is preserved. DADA2's score scheme maps to WFA penalties via the Eizenga adjustment (`match_: -5, mismatch: 4, gap_opening: 0, gap_extension: 8`).
- **`--align-backend nw|wfa2`** (default `nw`) on `dada`, `dada-pooled`, `dada-pseudo`, `learn-errors`, `errors-from-sample`, and `remove-bimera-denovo`. The chimera path dispatches via its own `BimeraAlignParams.backend`, so the toggle is honored everywhere, not just in dada/learn-errors. (`DADA2RS_ALIGN_BACKEND=wfa` kept as an undocumented fallback.)
- **Error-model provenance**: the backend is baked into the `learn-errors` JSON (`LearnedErrParams`) and rides the existing `resolve!`/`--inherit-err-params`/consistency-warning machinery, keeping `learn-errors` and `dada` consistent.
- **Concordance CI**: an Illumina WFA gate runs the full pipeline with `--align-backend wfa2` against the same static R reference with the same thresholds.

## Results

- **ASV-equivalent on real data**: identical ASV table (sequences + abundances, churn=0) vs the NW backend on Illumina (sam1+sam2) and PacBio HiFi (samPB) — only sub-threshold diagnostic `birth_*` stats differ. The Illumina WFA concordance gate passes with recall/precision/count-corr = 1.000, matching NW.
- **Known divergence (documented, not ASV-affecting)**: WFA's ends-free path is not byte-identical to `align_endsfree` at gap/homopolymer boundaries and sequence ends (~5.5% of synthetic random pairs; isolated to free-end-gap crediting via `wfa_global_isolation`). It does not propagate to ASVs on screened, band-limited real data.

## Caveats / why "experimental"

- **PacBio performance**: even after caching a per-thread aligner (>13× → ~4.3× vs NW), WFA is still slower than NW on long reads, so the **PacBio WFA concordance gate is deliberately deferred** pending further profiling. Illumina is unaffected.
- The fork's ends-free free-end-gap crediting fix is a follow-up (reproducer: `wfa_diagnose`).
- Depends on a **git-pinned** rev of the public HPCBio `wfa2lib-rs` fork (not yet on crates.io). Local fork iteration uses a git-ignored `.cargo/config.toml` `paths` override; `Cargo.lock` records the git source so CI is unaffected. Bumps MSRV 1.87 → 1.91 (the dependency's MSRV).

## Default behavior unchanged

`nw` remains the default everywhere; with the flag unset there is no behavior change. CI (concordance) is green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)