### PR TITLE
feat: chimera-diagnostics — higher-order (trimera) screening

### DIFF
--- a/dev/benchmark/bench_pooled.py
+++ b/dev/benchmark/bench_pooled.py
@@ -555,6 +555,15 @@ def _run_full_pipeline(args, bin_, outdir):
     wall = sum(r["wall_s"] for r in rows_c)
     cpu = sum(r.get("cpu_s", 0.0) for r in rows_c)
     peak = max((r["maxrss_kb"] for r in rows_c), default=0)
+    # Per-step breakdown for this arm (cores = cpu/wall per step) so core usage
+    # can be inspected after the fact under the default --sample-jobs, without
+    # re-running. One row per pipeline step; learn/dada are where WFA's cost
+    # concentrates (issue #51).
+    with open(outdir / "steps.csv", "w") as sf:
+        sf.write("step,wall_s,cpu_s,cores,maxrss_kb\n")
+        for r in rows_c:
+            sf.write(f"{r['step']},{r['wall_s']:.2f},{r.get('cpu_s', 0.0):.2f},"
+                     f"{cores(r):.2f},{r['maxrss_kb']:.0f}\n")
     return wall, cpu, peak, load_table(outdir / "seqtab_nochim.json")
 
 

--- a/dev/benchmark/compare_cluster_log.py
+++ b/dev/benchmark/compare_cluster_log.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Compare dada/learn-errors verbose cluster logs across alignment backends.
+
+Quantifies E-M convergence behaviour from the `--verbose` "New Cluster" output
+so backend A/B differences (e.g. NW vs experimental WFA) are read off the logs
+instead of eyeballed. Two signals:
+
+  births     — number of "New Cluster" lines = cluster-birth steps summed over
+               all dada calls / self-consistency rounds. A large delta between
+               backends is a convergence-TRAJECTORY difference (the slightly
+               different alignments push learn-errors down a different number of
+               rounds), not a per-step instability.
+  shuffle-S  — each 'S' on a "New Cluster" line is one b_shuffle2 round (reads
+               reassigned among clusters until the partition is stable). The
+               textual tokens on those lines have no capital S, so the count is
+               exact. mean S/birth is the per-step convergence cost; if it
+               matches across backends, the backend is NOT destabilising E-M
+               even if the raw 'S' runs look long.
+
+Usage:
+  compare_cluster_log.py LABEL=path/to.log [LABEL=path/to.log ...]
+  # e.g. compare across arms and read directions:
+  compare_cluster_log.py \\
+      nw-fwd=nw/learn_fwd.log  e50-fwd=e50/learn_fwd.log \\
+      nw-rev=nw/learn_rev.log  e50-rev=e50/learn_rev.log
+
+Background: dada2-rs issue #51 (WFA edit-budget cap) scale validation. The MiSeq
+finding was per-birth shuffle cost identical NW vs WFA (~2.3 fwd / ~2.5 rev);
+the only real divergence was total births on the lower-quality REVERSE reads.
+"""
+import sys
+
+
+def summarize(path):
+    births = 0
+    shuffle_s = 0
+    max_run = 0
+    long_runs = 0  # births that took >=4 shuffle rounds
+    try:
+        fh = open(path)
+    except OSError as e:
+        return None, str(e)
+    with fh:
+        for line in fh:
+            if "New Cluster" in line:
+                births += 1
+                c = line.count("S")  # all S on this line are shuffle markers
+                shuffle_s += c
+                max_run = max(max_run, c)
+                if c >= 4:
+                    long_runs += 1
+    mean = shuffle_s / births if births else 0.0
+    return (births, shuffle_s, mean, max_run, long_runs), None
+
+
+def main(argv):
+    if len(argv) < 2 or any("=" not in a for a in argv[1:]):
+        sys.exit(f"usage: {argv[0]} LABEL=path.log [LABEL=path.log ...]")
+    rows = []
+    width = max(len(a.split("=", 1)[0]) for a in argv[1:])
+    for spec in argv[1:]:
+        label, path = spec.split("=", 1)
+        stats, err = summarize(path)
+        if err:
+            print(f"{label:>{width}}: <skip: {err}>")
+            continue
+        births, s, mean, mx, long = stats
+        rows.append((label, births, s, mean, mx, long))
+
+    if not rows:
+        return
+    hdr = f"{'label':>{width}}  {'births':>8} {'shuffleS':>9} {'mean S/birth':>13} {'max_run':>8} {'>=4S':>7}"
+    print(hdr)
+    print("-" * len(hdr))
+    for label, births, s, mean, mx, long in rows:
+        print(
+            f"{label:>{width}}  {births:>8d} {s:>9d} {mean:>13.2f} {mx:>8d} {long:>7d}"
+        )
+    print(
+        "\nread: matching 'mean S/birth' across backends = E-M equally stable "
+        "per step\n      (long S runs are normal, not a backend artifact); a "
+        "large 'births'\n      delta = convergence-trajectory difference, "
+        "watch it on lower-quality\n      (reverse / noisier) reads where "
+        "backends diverge most."
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/src/chimera.rs
+++ b/src/chimera.rs
@@ -431,3 +431,279 @@ pub fn table_bimera2(
         })
         .collect()
 }
+
+// ---------------------------------------------------------------------------
+// Coverage diagnostics (higher-order chimera screen)
+// ---------------------------------------------------------------------------
+
+/// Per-sequence bimera *coverage* diagnostic.
+///
+/// The boolean `is_bimera` decision collapses the question "does one junction
+/// of two more-abundant parents cover the whole read?" into a yes/no and throws
+/// away the underlying coverage. That coverage is exactly the signal for
+/// higher-order chimeras (trimeras): a read whose best single-junction model
+/// *almost* spans the full length, leaving a small internal gap, is a candidate
+/// chimera of three or more parents.
+///
+/// Coverage here is measured under the **strict** (no one-off) model so the gap
+/// boundaries are not blurred by junction mismatches, and under the **pooled**
+/// abundance model (abundances summed across samples) for parent selection.
+/// All coordinates are in query-base units.
+pub struct BimeraDiagnostic {
+    /// Strict single-junction decision: `max_left + max_right >= sqlen`.
+    pub is_bimera: bool,
+    pub sqlen: usize,
+    /// Longest strict left overlap with any valid parent.
+    pub max_left: usize,
+    /// Longest strict right overlap with any valid parent.
+    pub max_right: usize,
+    /// Parent column index achieving `max_left` (`None` if no valid parent).
+    pub best_left_parent: Option<usize>,
+    /// Parent column index achieving `max_right`.
+    pub best_right_parent: Option<usize>,
+    /// Residual uncovered query interval `[gap_start, gap_end)`. Empty when the
+    /// read is a clean bimera (`gap_start == gap_end == sqlen`).
+    pub gap_start: usize,
+    pub gap_end: usize,
+    /// Third-parent confirmatory test: the parent (other than the two end
+    /// parents) with the fewest mismatches across the residual gap, and that
+    /// mismatch count. `gap_mismatches == 0` with a `third_parent` means three
+    /// parents fully reconstruct the read — a confirmed trimera. `None` /
+    /// large counts suggest the gap is novel biological sequence instead.
+    pub third_parent: Option<usize>,
+    pub gap_mismatches: usize,
+}
+
+/// Count mismatches of parent `al_p` against query `al_q` across the query
+/// interval `[q_start, q_end)`, walking alignment columns and mapping non-gap
+/// query columns to query base indices. Parent gaps (deletions relative to the
+/// query) within the region count as mismatches; parent insertions (query gap)
+/// are ignored as they do not advance the query coordinate.
+fn gap_mismatch_count(al_q: &[u8], al_p: &[u8], q_start: usize, q_end: usize) -> usize {
+    let mut qi = 0usize;
+    let mut mm = 0usize;
+    for c in 0..al_q.len() {
+        if al_q[c] != b'-' {
+            if qi >= q_start && qi < q_end && al_p[c] != al_q[c] {
+                mm += 1;
+            }
+            qi += 1;
+            if qi >= q_end {
+                break;
+            }
+        }
+    }
+    mm
+}
+
+/// Compute [`BimeraDiagnostic`]s for every sequence under the pooled model.
+///
+/// `pooled[j]` is the summed abundance of sequence `j` across all samples.
+/// Parent selection mirrors the pooled `is_bimera` path: a sequence `k` is a
+/// candidate parent of `j` when `pooled[k] > min_fold * pooled[j]` and
+/// `pooled[k] >= min_abund`.
+///
+/// Runs two alignment passes per query: pass 1 finds the best left/right
+/// coverage (and end parents); pass 2 — only when the read is not already a
+/// strict bimera — re-aligns the parents to score the residual gap for a third
+/// parent. Parallel over sequences via Rayon.
+pub fn pooled_diagnostics(
+    pooled: &[u32],
+    seqs: &[&[u8]],
+    min_fold: f64,
+    min_abund: u32,
+    params: &BimeraAlignParams,
+) -> Vec<BimeraDiagnostic> {
+    let BimeraAlignParams {
+        match_score,
+        mismatch,
+        gap_p,
+        max_shift,
+        backend,
+        wfa_max_edits,
+        ..
+    } = *params;
+    let align_scores = VectorizedAlignScores {
+        match_score,
+        mismatch,
+        gap_p,
+        end_gap_p: 0,
+        band: max_shift,
+    };
+    let max_steps = wfa_cost_cap(wfa_max_edits, gap_p as i32);
+    let ncol = seqs.len();
+    assert_eq!(pooled.len(), ncol, "pooled length must equal seqs length");
+
+    (0..ncol)
+        .into_par_iter()
+        .map_init(AlignBuffers::new, |buf, j| {
+            let sq = seqs[j];
+            let sqlen = sq.len();
+            let abund = pooled[j];
+
+            let mut d = BimeraDiagnostic {
+                is_bimera: false,
+                sqlen,
+                max_left: 0,
+                max_right: 0,
+                best_left_parent: None,
+                best_right_parent: None,
+                gap_start: sqlen,
+                gap_end: sqlen,
+                third_parent: None,
+                gap_mismatches: 0,
+            };
+
+            if abund == 0 {
+                return d;
+            }
+            let parents: Vec<usize> = (0..ncol)
+                .filter(|&k| {
+                    k != j && pooled[k] as f64 > min_fold * abund as f64 && pooled[k] >= min_abund
+                })
+                .collect();
+            if parents.len() < 2 {
+                return d;
+            }
+
+            // Pass 1: strict left/right coverage and the parents achieving it.
+            for &k in &parents {
+                bimera_align(sq, seqs[k], &align_scores, backend, max_steps, buf);
+                let (al0, al1) = buf.alignment();
+                let (left, right, _, _) = get_lr(al0, al1, false, max_shift as usize);
+                // Skip identity / pure-shift / internal-indel parents.
+                if left + right >= sqlen {
+                    continue;
+                }
+                if left > d.max_left {
+                    d.max_left = left;
+                    d.best_left_parent = Some(k);
+                }
+                if right > d.max_right {
+                    d.max_right = right;
+                    d.best_right_parent = Some(k);
+                }
+            }
+
+            d.is_bimera = d.max_left + d.max_right >= sqlen;
+            if d.is_bimera {
+                return d;
+            }
+            d.gap_start = d.max_left.min(sqlen);
+            d.gap_end = sqlen.saturating_sub(d.max_right).max(d.gap_start);
+
+            // Pass 2: third-parent fit across the residual gap. Exclude the two
+            // end parents so a hit is a genuinely distinct third source.
+            let mut best_mm = usize::MAX;
+            let mut best_k = None;
+            for &k in &parents {
+                if Some(k) == d.best_left_parent || Some(k) == d.best_right_parent {
+                    continue;
+                }
+                bimera_align(sq, seqs[k], &align_scores, backend, max_steps, buf);
+                let (al0, al1) = buf.alignment();
+                let mm = gap_mismatch_count(al0, al1, d.gap_start, d.gap_end);
+                if mm < best_mm {
+                    best_mm = mm;
+                    best_k = Some(k);
+                }
+            }
+            d.third_parent = best_k;
+            d.gap_mismatches = if best_mm == usize::MAX { 0 } else { best_mm };
+            d
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params() -> BimeraAlignParams {
+        BimeraAlignParams {
+            allow_one_off: false,
+            min_one_off_par_dist: 4,
+            match_score: 5,
+            mismatch: -4,
+            gap_p: -8,
+            max_shift: 16,
+            backend: AlignBackend::Nw,
+            wfa_max_edits: 0,
+        }
+    }
+
+    /// A query built as L+M+R, with one high-abundance parent each contributing
+    /// L (left), R (right), and M (middle), must be flagged as NOT a strict
+    /// bimera but with a residual gap that a distinct third parent fills cleanly.
+    #[test]
+    fn pooled_diagnostics_detects_trimera() {
+        const L: &[u8] = b"ACGTACGTACGTACGTACGT"; // 20
+        const M: &[u8] = b"TTTTGGGGCCCCAAAATTTT"; // 20
+        const R: &[u8] = b"GATTACAGATTACAGATTAC"; // 20
+
+        let query: Vec<u8> = [L, M, R].concat(); // sqlen 60
+        let par_a: Vec<u8> = [
+            L,
+            &b"AAAAAAAAAAAAAAAAAAAA"[..],
+            &b"CCCCCCCCCCCCCCCCCCCC"[..],
+        ]
+        .concat();
+        let par_b: Vec<u8> = [
+            &b"GCGCGCGCGCGCGCGCGCGC"[..],
+            &b"GCGCGCGCGCGCGCGCGCGC"[..],
+            R,
+        ]
+        .concat();
+        let par_c: Vec<u8> = [
+            &b"CACACACACACACACACACA"[..],
+            M,
+            &b"TGTGTGTGTGTGTGTGTGTG"[..],
+        ]
+        .concat();
+
+        let seqs: Vec<&[u8]> = vec![&query, &par_a, &par_b, &par_c];
+        // query low abundance, parents high.
+        let pooled = vec![2u32, 100, 100, 100];
+
+        let d = pooled_diagnostics(&pooled, &seqs, 1.5, 2, &params());
+        let q = &d[0];
+
+        assert!(
+            !q.is_bimera,
+            "single junction should not cover the full read"
+        );
+        assert_eq!(q.max_left, 20, "left parent covers L");
+        assert_eq!(q.max_right, 20, "right parent covers R");
+        assert_eq!(q.best_left_parent, Some(1));
+        assert_eq!(q.best_right_parent, Some(2));
+        assert_eq!((q.gap_start, q.gap_end), (20, 40), "gap is the middle M");
+        assert_eq!(q.third_parent, Some(3), "parent C fills the gap");
+        // C matches the 20-base middle up to minor ends-free boundary slack.
+        assert!(
+            q.gap_mismatches <= 2,
+            "third parent should fill the gap nearly cleanly, got {}",
+            q.gap_mismatches
+        );
+    }
+
+    /// A genuine bimera (L from one parent, R from another) is flagged
+    /// is_bimera with no residual gap.
+    #[test]
+    fn pooled_diagnostics_flags_plain_bimera() {
+        const L: &[u8] = b"ACGTACGTACGTACGTACGT";
+        const R: &[u8] = b"GATTACAGATTACAGATTAC";
+
+        let query: Vec<u8> = [L, R].concat(); // 40
+        let par_a: Vec<u8> = [L, &b"CCCCCCCCCCCCCCCCCCCC"[..]].concat();
+        let par_b: Vec<u8> = [&b"GGGGGGGGGGGGGGGGGGGG"[..], R].concat();
+
+        let seqs: Vec<&[u8]> = vec![&query, &par_a, &par_b];
+        let pooled = vec![2u32, 100, 100];
+
+        let d = pooled_diagnostics(&pooled, &seqs, 1.5, 2, &params());
+        let q = &d[0];
+
+        assert!(q.is_bimera);
+        assert_eq!(q.gap_start, q.gap_end, "no residual gap for a clean bimera");
+    }
+}

--- a/src/chimera.rs
+++ b/src/chimera.rs
@@ -472,6 +472,18 @@ pub struct BimeraDiagnostic {
     /// large counts suggest the gap is novel biological sequence instead.
     pub third_parent: Option<usize>,
     pub gap_mismatches: usize,
+    /// Minimum ends-free Hamming distance to any single candidate parent. The
+    /// key disambiguator: a few-SNP *variant* of one abundant parent has a small
+    /// value here and is NOT a chimera, even though it leaves a coverage gap; a
+    /// genuine mosaic is close to no single parent (large value). See
+    /// [`get_ham_endsfree`]. `usize::MAX` when there are no candidate parents.
+    pub nearest_parent_dist: usize,
+    /// Fewest mismatches across the residual gap achieved by either *end* parent
+    /// (`best_left_parent` / `best_right_parent`). The baseline the third parent
+    /// must beat: if `gap_mismatches` is not meaningfully below this, the gap is
+    /// explained just as well by an end parent (i.e. a variant), not a third
+    /// source. `usize::MAX` when not computed (bimera / no parents).
+    pub gap_end_parent_mismatches: usize,
 }
 
 /// Count mismatches of parent `al_p` against query `al_q` across the query
@@ -552,6 +564,8 @@ pub fn pooled_diagnostics(
                 gap_end: sqlen,
                 third_parent: None,
                 gap_mismatches: 0,
+                nearest_parent_dist: usize::MAX,
+                gap_end_parent_mismatches: usize::MAX,
             };
 
             if abund == 0 {
@@ -566,10 +580,17 @@ pub fn pooled_diagnostics(
                 return d;
             }
 
-            // Pass 1: strict left/right coverage and the parents achieving it.
+            // Pass 1: strict left/right coverage, the parents achieving it, and
+            // the nearest single parent (ends-free Hamming) — the disambiguator
+            // between a few-SNP variant and a genuine mosaic.
+            let mut nearest = usize::MAX;
             for &k in &parents {
                 bimera_align(sq, seqs[k], &align_scores, backend, max_steps, buf);
                 let (al0, al1) = buf.alignment();
+                let dist = get_ham_endsfree(al0, al1);
+                if dist < nearest {
+                    nearest = dist;
+                }
                 let (left, right, _, _) = get_lr(al0, al1, false, max_shift as usize);
                 // Skip identity / pure-shift / internal-indel parents.
                 if left + right >= sqlen {
@@ -584,6 +605,7 @@ pub fn pooled_diagnostics(
                     d.best_right_parent = Some(k);
                 }
             }
+            d.nearest_parent_dist = nearest;
 
             d.is_bimera = d.max_left + d.max_right >= sqlen;
             if d.is_bimera {
@@ -592,24 +614,28 @@ pub fn pooled_diagnostics(
             d.gap_start = d.max_left.min(sqlen);
             d.gap_end = sqlen.saturating_sub(d.max_right).max(d.gap_start);
 
-            // Pass 2: third-parent fit across the residual gap. Exclude the two
-            // end parents so a hit is a genuinely distinct third source.
+            // Pass 2: score the residual gap. The two end parents give the
+            // baseline a third source must beat; the best non-end parent is the
+            // third-parent candidate.
             let mut best_mm = usize::MAX;
             let mut best_k = None;
+            let mut end_mm = usize::MAX;
             for &k in &parents {
-                if Some(k) == d.best_left_parent || Some(k) == d.best_right_parent {
-                    continue;
-                }
                 bimera_align(sq, seqs[k], &align_scores, backend, max_steps, buf);
                 let (al0, al1) = buf.alignment();
                 let mm = gap_mismatch_count(al0, al1, d.gap_start, d.gap_end);
-                if mm < best_mm {
+                if Some(k) == d.best_left_parent || Some(k) == d.best_right_parent {
+                    if mm < end_mm {
+                        end_mm = mm;
+                    }
+                } else if mm < best_mm {
                     best_mm = mm;
                     best_k = Some(k);
                 }
             }
             d.third_parent = best_k;
             d.gap_mismatches = if best_mm == usize::MAX { 0 } else { best_mm };
+            d.gap_end_parent_mismatches = end_mm;
             d
         })
         .collect()
@@ -683,6 +709,61 @@ mod tests {
             q.gap_mismatches <= 2,
             "third parent should fill the gap nearly cleanly, got {}",
             q.gap_mismatches
+        );
+        // A genuine mosaic is close to no single parent...
+        assert!(
+            q.nearest_parent_dist >= 20,
+            "mosaic should not be near any single parent, got {}",
+            q.nearest_parent_dist
+        );
+        // ...and the third parent must beat the end parents in the gap.
+        assert!(
+            q.gap_mismatches < q.gap_end_parent_mismatches,
+            "third parent ({}) must beat end parents ({}) in the gap",
+            q.gap_mismatches,
+            q.gap_end_parent_mismatches
+        );
+    }
+
+    /// A few-SNP variant of a single abundant parent leaves a coverage gap but
+    /// is NOT a chimera: it sits very close to one parent, and no third parent
+    /// explains the gap better than that parent does. (The confound found on the
+    /// real nodA data.)
+    #[test]
+    fn pooled_diagnostics_rejects_snp_variant() {
+        // 60 bp parent with low internal self-similarity.
+        let par_a: Vec<u8> =
+            b"ACGTTGCAACGTTGCAACGTTGCAACGTTGCAACGTTGCAACGTTGCAACGTTGCAACGT".to_vec();
+        assert_eq!(par_a.len(), 60);
+        // Query = par_a with 3 internal substitutions at 20, 30, 40.
+        let mut query = par_a.clone();
+        for &p in &[20usize, 30, 40] {
+            query[p] = if query[p] == b'A' { b'C' } else { b'A' };
+        }
+        let par_x: Vec<u8> =
+            b"TTTTTTTTTTGGGGGGGGGGCCCCCCCCCCAAAAAAAAAATTTTTTTTTTGGGGGGGGGG".to_vec();
+        let par_y: Vec<u8> =
+            b"GAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGAGA".to_vec();
+
+        let seqs: Vec<&[u8]> = vec![&query, &par_a, &par_x, &par_y];
+        let pooled = vec![2u32, 100, 100, 100];
+
+        let d = pooled_diagnostics(&pooled, &seqs, 1.5, 2, &params());
+        let q = &d[0];
+
+        assert!(!q.is_bimera);
+        assert_eq!(
+            q.nearest_parent_dist, 3,
+            "variant is 3 SNPs from its single parent"
+        );
+        // The gap is explained at least as well by an end parent as by any
+        // third parent, so it must not pass a "third beats end" trimera gate.
+        assert!(
+            q.gap_mismatches >= q.gap_end_parent_mismatches,
+            "no third parent should beat the end parent for a SNP variant \
+             (third={}, end={})",
+            q.gap_mismatches,
+            q.gap_end_parent_mismatches
         );
     }
 

--- a/src/chimera_diagnostics.rs
+++ b/src/chimera_diagnostics.rs
@@ -1,0 +1,156 @@
+//! Higher-order chimera (trimera) diagnostics over a sequence table.
+//!
+//! `remove-bimera-denovo` answers a binary question per sequence — is it a
+//! chimera of two more-abundant parents? — and discards the coverage that led
+//! to that answer. Some lower-abundance reads (notably on long amplicons such
+//! as full-length 16S or `nodA`, and in low-biomass samples) survive bimera
+//! removal yet look chimeric, consistent with being chimeras of *three or more*
+//! parents. The bimera coverage signal is exactly what flags these: a read
+//! whose best single-junction model nearly spans its full length leaves a small
+//! internal gap that a third parent can fill.
+//!
+//! This module runs [`pooled_diagnostics`] over a [`SequenceTable`] and emits a
+//! per-sequence TSV. It does not filter or modify the table.
+
+use std::io::{self, Write};
+
+use crate::chimera::{BimeraAlignParams, BimeraDiagnostic, pooled_diagnostics};
+use crate::remove_bimera::BimeraParams;
+use crate::sequence_table::SequenceTable;
+
+/// One TSV row of diagnostics for a sequence.
+pub struct DiagnosticRow<'a> {
+    pub sequence_id: &'a str,
+    pub length: usize,
+    pub total_abundance: u32,
+    pub n_samples: u32,
+    pub is_bimera: bool,
+    pub max_left: usize,
+    pub max_right: usize,
+    pub cover: usize,
+    pub cover_frac: f64,
+    pub gap_len: usize,
+    pub gap_start: usize,
+    pub gap_end: usize,
+    pub best_left_parent: Option<&'a str>,
+    pub best_right_parent: Option<&'a str>,
+    pub third_parent: Option<&'a str>,
+    pub gap_mismatches: usize,
+    /// Heuristic screen: survived the strict bimera test but a single junction
+    /// covers at least `min_cover_frac` of the read, leaving a real gap.
+    pub trimera_suspect: bool,
+}
+
+/// Run the pooled bimera coverage diagnostic over `table`.
+///
+/// `min_cover_frac` sets the `trimera_suspect` threshold on `cover / length`.
+/// Returns one [`DiagnosticRow`] per sequence, in table column order.
+pub fn run_diagnostics<'a>(
+    table: &'a SequenceTable,
+    params: &BimeraParams,
+    min_cover_frac: f64,
+) -> Vec<DiagnosticRow<'a>> {
+    let ncol = table.sequences.len();
+    let nrow = table.samples.len();
+    if ncol == 0 || nrow == 0 {
+        return Vec::new();
+    }
+
+    let pooled: Vec<u32> = (0..ncol)
+        .map(|j| (0..nrow).map(|i| table.counts[i][j] as u32).sum())
+        .collect();
+    let n_samples: Vec<u32> = (0..ncol)
+        .map(|j| (0..nrow).filter(|&i| table.counts[i][j] > 0).count() as u32)
+        .collect();
+
+    let seq_bytes: Vec<&[u8]> = table.sequences.iter().map(|s| s.as_bytes()).collect();
+
+    let align_params = BimeraAlignParams {
+        allow_one_off: params.allow_one_off,
+        min_one_off_par_dist: params.min_one_off_parent_distance,
+        match_score: params.match_score,
+        mismatch: params.mismatch,
+        gap_p: params.gap_p,
+        max_shift: params.max_shift,
+        backend: params.backend,
+        wfa_max_edits: params.wfa_max_edits,
+    };
+
+    let diags = pooled_diagnostics(
+        &pooled,
+        &seq_bytes,
+        params.min_fold_parent_over_abundance,
+        params.min_parent_abundance,
+        &align_params,
+    );
+
+    let id = |k: Option<usize>| k.map(|k| table.sequence_ids[k].as_str());
+
+    diags
+        .iter()
+        .enumerate()
+        .map(|(j, d): (usize, &BimeraDiagnostic)| {
+            let cover = (d.max_left + d.max_right).min(d.sqlen);
+            let cover_frac = if d.sqlen > 0 {
+                cover as f64 / d.sqlen as f64
+            } else {
+                0.0
+            };
+            let gap_len = d.gap_end.saturating_sub(d.gap_start);
+            let trimera_suspect = !d.is_bimera && gap_len > 0 && cover_frac >= min_cover_frac;
+            DiagnosticRow {
+                sequence_id: table.sequence_ids[j].as_str(),
+                length: d.sqlen,
+                total_abundance: pooled[j],
+                n_samples: n_samples[j],
+                is_bimera: d.is_bimera,
+                max_left: d.max_left,
+                max_right: d.max_right,
+                cover,
+                cover_frac,
+                gap_len,
+                gap_start: d.gap_start,
+                gap_end: d.gap_end,
+                best_left_parent: id(d.best_left_parent),
+                best_right_parent: id(d.best_right_parent),
+                third_parent: id(d.third_parent),
+                gap_mismatches: d.gap_mismatches,
+                trimera_suspect,
+            }
+        })
+        .collect()
+}
+
+const HEADER: &str = "sequence_id\tlength\ttotal_abundance\tn_samples\tis_bimera\t\
+max_left\tmax_right\tcover\tcover_frac\tgap_len\tgap_start\tgap_end\t\
+best_left_parent\tbest_right_parent\tthird_parent\tgap_mismatches\ttrimera_suspect";
+
+/// Write diagnostics rows as TSV (header + one row per sequence) to `w`.
+pub fn write_tsv<W: Write>(rows: &[DiagnosticRow<'_>], w: &mut W) -> io::Result<()> {
+    writeln!(w, "{HEADER}")?;
+    let na = "NA";
+    for r in rows {
+        writeln!(
+            w,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.4}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            r.sequence_id,
+            r.length,
+            r.total_abundance,
+            r.n_samples,
+            r.is_bimera,
+            r.max_left,
+            r.max_right,
+            r.cover,
+            r.cover_frac,
+            r.gap_len,
+            r.gap_start,
+            r.gap_end,
+            r.best_left_parent.unwrap_or(na),
+            r.best_right_parent.unwrap_or(na),
+            r.third_parent.unwrap_or(na),
+            r.gap_mismatches,
+            r.trimera_suspect,
+        )?;
+    }
+    Ok(())
+}

--- a/src/chimera_diagnostics.rs
+++ b/src/chimera_diagnostics.rs
@@ -36,19 +36,54 @@ pub struct DiagnosticRow<'a> {
     pub best_right_parent: Option<&'a str>,
     pub third_parent: Option<&'a str>,
     pub gap_mismatches: usize,
-    /// Heuristic screen: survived the strict bimera test but a single junction
-    /// covers at least `min_cover_frac` of the read, leaving a real gap.
+    /// Mismatches the better *end* parent leaves across the gap (`usize::MAX` =
+    /// not computed). The baseline a third parent must beat.
+    pub gap_end_parent_mismatches: usize,
+    /// Ends-free Hamming distance to the nearest single parent (`usize::MAX` =
+    /// no candidate parent). Small = few-SNP variant; large = mosaic.
+    pub nearest_parent_dist: usize,
+    /// Refined screen (see [`TrimeraCriteria`]): the read is not a bimera, is
+    /// far from any single parent, and a distinct third parent explains a
+    /// non-trivial gap better than either end parent.
     pub trimera_suspect: bool,
+}
+
+/// Thresholds for the `trimera_suspect` call. Defaults are tuned on ~600 bp nodA
+/// amplicons; see CLI `--trimera-*` flags.
+#[derive(Clone, Copy, Debug)]
+pub struct TrimeraCriteria {
+    /// Minimum distance to the nearest single parent — rejects few-SNP variants.
+    pub min_parent_dist: usize,
+    /// Minimum gap length for a credible third segment — rejects one-off bimeras.
+    pub min_gap_len: usize,
+    /// Maximum third-parent mismatch fraction across the gap (clean fit).
+    pub max_gap_error_frac: f64,
+    /// Minimum length of *each* end flank (`max_left` and `max_right`). A
+    /// 3-segment mosaic needs two real junctions, hence two substantial flanks;
+    /// this rejects tiny-flank divergent singletons whose "gap" is nearly the
+    /// whole read.
+    pub min_flank: usize,
+}
+
+impl Default for TrimeraCriteria {
+    fn default() -> Self {
+        Self {
+            min_parent_dist: 15,
+            min_gap_len: 20,
+            max_gap_error_frac: 0.10,
+            min_flank: 30,
+        }
+    }
 }
 
 /// Run the pooled bimera coverage diagnostic over `table`.
 ///
-/// `min_cover_frac` sets the `trimera_suspect` threshold on `cover / length`.
-/// Returns one [`DiagnosticRow`] per sequence, in table column order.
+/// `crit` sets the `trimera_suspect` thresholds. Returns one [`DiagnosticRow`]
+/// per sequence, in table column order.
 pub fn run_diagnostics<'a>(
     table: &'a SequenceTable,
     params: &BimeraParams,
-    min_cover_frac: f64,
+    crit: TrimeraCriteria,
 ) -> Vec<DiagnosticRow<'a>> {
     let ncol = table.sequences.len();
     let nrow = table.samples.len();
@@ -97,7 +132,25 @@ pub fn run_diagnostics<'a>(
                 0.0
             };
             let gap_len = d.gap_end.saturating_sub(d.gap_start);
-            let trimera_suspect = !d.is_bimera && gap_len > 0 && cover_frac >= min_cover_frac;
+            // Refined trimera screen. A genuine higher-order chimera: (1) is not
+            // a bimera, (2) sits far from every single parent (not a SNP
+            // variant), (3) has a non-trivial gap, (4) has a distinct third
+            // parent that fills the gap cleanly AND strictly better than either
+            // end parent does (else the gap is just variation an end parent
+            // already explains).
+            let gap_err_frac = if gap_len > 0 {
+                d.gap_mismatches as f64 / gap_len as f64
+            } else {
+                1.0
+            };
+            let trimera_suspect = !d.is_bimera
+                && d.nearest_parent_dist >= crit.min_parent_dist
+                && d.max_left >= crit.min_flank
+                && d.max_right >= crit.min_flank
+                && gap_len >= crit.min_gap_len
+                && d.third_parent.is_some()
+                && gap_err_frac <= crit.max_gap_error_frac
+                && d.gap_mismatches < d.gap_end_parent_mismatches;
             DiagnosticRow {
                 sequence_id: table.sequence_ids[j].as_str(),
                 length: d.sqlen,
@@ -115,6 +168,8 @@ pub fn run_diagnostics<'a>(
                 best_right_parent: id(d.best_right_parent),
                 third_parent: id(d.third_parent),
                 gap_mismatches: d.gap_mismatches,
+                gap_end_parent_mismatches: d.gap_end_parent_mismatches,
+                nearest_parent_dist: d.nearest_parent_dist,
                 trimera_suspect,
             }
         })
@@ -123,7 +178,18 @@ pub fn run_diagnostics<'a>(
 
 const HEADER: &str = "sequence_id\tlength\ttotal_abundance\tn_samples\tis_bimera\t\
 max_left\tmax_right\tcover\tcover_frac\tgap_len\tgap_start\tgap_end\t\
-best_left_parent\tbest_right_parent\tthird_parent\tgap_mismatches\ttrimera_suspect";
+best_left_parent\tbest_right_parent\tthird_parent\tgap_mismatches\t\
+gap_end_parent_mismatches\tnearest_parent_dist\ttrimera_suspect";
+
+/// Format a `usize` count as a TSV cell, rendering the `usize::MAX` sentinel
+/// ("not computed") as `NA`.
+fn cell(v: usize) -> String {
+    if v == usize::MAX {
+        "NA".to_string()
+    } else {
+        v.to_string()
+    }
+}
 
 /// Write diagnostics rows as TSV (header + one row per sequence) to `w`.
 pub fn write_tsv<W: Write>(rows: &[DiagnosticRow<'_>], w: &mut W) -> io::Result<()> {
@@ -132,7 +198,7 @@ pub fn write_tsv<W: Write>(rows: &[DiagnosticRow<'_>], w: &mut W) -> io::Result<
     for r in rows {
         writeln!(
             w,
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.4}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{:.4}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             r.sequence_id,
             r.length,
             r.total_abundance,
@@ -149,6 +215,8 @@ pub fn write_tsv<W: Write>(rows: &[DiagnosticRow<'_>], w: &mut W) -> io::Result<
             r.best_right_parent.unwrap_or(na),
             r.third_parent.unwrap_or(na),
             r.gap_mismatches,
+            cell(r.gap_end_parent_mismatches),
+            cell(r.nearest_parent_dist),
             r.trimera_suspect,
         )?;
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1189,6 +1189,68 @@ pub enum Commands {
         compact: bool,
     },
 
+    /// Screen a sequence table for higher-order chimeras (trimeras)
+    ///
+    /// Reads JSON from `make-sequence-table` or `remove-bimera-denovo` and emits
+    /// a per-sequence TSV of bimera *coverage* metrics. Unlike the boolean
+    /// `remove-bimera-denovo` decision, this retains how much of each read a
+    /// single two-parent junction explains: a read that survives bimera removal
+    /// yet is nearly covered (`cover_frac` high) leaves a small internal gap a
+    /// third parent can fill — a trimera suspect. Useful on long amplicons
+    /// (full-length 16S, nodA) and low-biomass samples where complex chimeras
+    /// are more likely. Coverage uses the pooled (across-sample) abundance model.
+    #[command(display_order = 14)]
+    ChimeraDiagnostics {
+        /// Sequence table JSON produced by `make-sequence-table` or `remove-bimera-denovo`
+        input: PathBuf,
+
+        /// Minimum fold-difference in abundance for a sequence to be a parent
+        #[arg(long, default_value_t = 1.5)]
+        min_fold_parent_over_abundance: f64,
+
+        /// Minimum abundance for a sequence to be a parent
+        #[arg(long, default_value_t = 2)]
+        min_parent_abundance: u32,
+
+        /// Maximum shift in ends-free alignment to potential parents
+        #[arg(long, default_value_t = 16)]
+        max_shift: i32,
+
+        /// Match score for the parent alignment (mirrors R's `MATCH`)
+        #[arg(long = "match", default_value_t = 5)]
+        match_score: i16,
+
+        /// Mismatch penalty for the parent alignment (mirrors R's `MISMATCH`)
+        #[arg(long, allow_hyphen_values = true, default_value_t = -4)]
+        mismatch: i16,
+
+        /// Gap penalty for the parent alignment (mirrors R's `GAP_PENALTY`)
+        #[arg(long, allow_hyphen_values = true, default_value_t = -8)]
+        gap_p: i16,
+
+        /// Pairwise alignment backend. `nw` (default) is Needleman-Wunsch; `wfa2`
+        /// is the experimental WFA backend.
+        #[arg(long, value_enum)]
+        align_backend: Option<AlignBackend>,
+
+        /// EXPERIMENTAL (with `--align-backend wfa2`): WFA edit-budget cap, in
+        /// edit operations. 0 = unbounded. [default: 50]
+        #[arg(long)]
+        wfa_max_edits: Option<i32>,
+
+        /// Minimum single-junction coverage fraction to flag a trimera suspect
+        #[arg(long, default_value_t = 0.9)]
+        trimera_min_cover_frac: f64,
+
+        /// Number of threads for parallel diagnostics
+        #[arg(long, default_value_t = 1)]
+        threads: usize,
+
+        /// Write TSV output to this file instead of stdout
+        #[arg(long, short = 'o')]
+        output: Option<PathBuf>,
+    },
+
     /// Convert a sequence table JSON to a tab-delimited count table
     ///
     /// Reads JSON produced by `make-sequence-table` or `remove-bimera-denovo`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1238,9 +1238,25 @@ pub enum Commands {
         #[arg(long)]
         wfa_max_edits: Option<i32>,
 
-        /// Minimum single-junction coverage fraction to flag a trimera suspect
-        #[arg(long, default_value_t = 0.9)]
-        trimera_min_cover_frac: f64,
+        /// Minimum distance to the nearest single parent to flag a trimera
+        /// suspect. Rejects few-SNP variants of one abundant parent, which leave
+        /// a coverage gap but are not chimeras.
+        #[arg(long, default_value_t = 15)]
+        trimera_min_parent_dist: usize,
+
+        /// Minimum residual gap length (bp) for a credible third segment.
+        /// Rejects one-off bimeras (gap of ~1 base).
+        #[arg(long, default_value_t = 20)]
+        trimera_min_gap: usize,
+
+        /// Maximum third-parent mismatch fraction across the gap (clean fit)
+        #[arg(long, default_value_t = 0.10)]
+        trimera_max_gap_error: f64,
+
+        /// Minimum length (bp) of each end flank. A 3-segment mosaic needs two
+        /// substantial flanks; rejects tiny-flank divergent singletons.
+        #[arg(long, default_value_t = 30)]
+        trimera_min_flank: usize,
 
         /// Number of threads for parallel diagnostics
         #[arg(long, default_value_t = 1)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use rand::seq::SliceRandom as _;
 use rayon::prelude::*;
 
 mod chimera;
+mod chimera_diagnostics;
 mod cli;
 mod cluster;
 mod cluster_trace;
@@ -2161,6 +2162,57 @@ fn main() -> io::Result<()> {
                 Some(path) => std::fs::write(&path, &json)?,
                 None => println!("{json}"),
             }
+        }
+
+        Commands::ChimeraDiagnostics {
+            input,
+            min_fold_parent_over_abundance,
+            min_parent_abundance,
+            max_shift,
+            match_score,
+            mismatch,
+            gap_p,
+            align_backend,
+            wfa_max_edits,
+            trimera_min_cover_frac,
+            threads,
+            output,
+        } => {
+            let table: SequenceTable =
+                read_tagged_json(&input, &["make-sequence-table", "remove-bimera-denovo"])
+                    .with_path(&input)?;
+
+            // One-off parameters are unused by the diagnostic (coverage is
+            // measured strictly); fill with the standard defaults.
+            let params = BimeraParams {
+                min_fold_parent_over_abundance,
+                min_parent_abundance,
+                allow_one_off: false,
+                min_one_off_parent_distance: 4,
+                max_shift,
+                min_sample_fraction: 0.9,
+                ignore_n_negatives: 1,
+                match_score,
+                mismatch,
+                gap_p,
+                backend: align_backend.unwrap_or_default(),
+                wfa_max_edits: wfa_max_edits.unwrap_or(WFA_MAX_EDITS_DEFAULT),
+            };
+
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .map_err(io::Error::other)?;
+            let rows = pool.install(|| {
+                chimera_diagnostics::run_diagnostics(&table, &params, trimera_min_cover_frac)
+            });
+
+            let mut out: Box<dyn io::Write> = match output {
+                Some(path) => Box::new(io::BufWriter::new(std::fs::File::create(&path)?)),
+                None => Box::new(io::BufWriter::new(io::stdout())),
+            };
+            chimera_diagnostics::write_tsv(&rows, &mut out)?;
+            out.flush()?;
         }
 
         Commands::SeqTableToTsv {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2174,7 +2174,10 @@ fn main() -> io::Result<()> {
             gap_p,
             align_backend,
             wfa_max_edits,
-            trimera_min_cover_frac,
+            trimera_min_parent_dist,
+            trimera_min_gap,
+            trimera_max_gap_error,
+            trimera_min_flank,
             threads,
             output,
         } => {
@@ -2203,9 +2206,13 @@ fn main() -> io::Result<()> {
                 .num_threads(threads)
                 .build()
                 .map_err(io::Error::other)?;
-            let rows = pool.install(|| {
-                chimera_diagnostics::run_diagnostics(&table, &params, trimera_min_cover_frac)
-            });
+            let crit = chimera_diagnostics::TrimeraCriteria {
+                min_parent_dist: trimera_min_parent_dist,
+                min_gap_len: trimera_min_gap,
+                max_gap_error_frac: trimera_max_gap_error,
+                min_flank: trimera_min_flank,
+            };
+            let rows = pool.install(|| chimera_diagnostics::run_diagnostics(&table, &params, crit));
 
             let mut out: Box<dyn io::Write> = match output {
                 Some(path) => Box::new(io::BufWriter::new(std::fs::File::create(&path)?)),


### PR DESCRIPTION
## Motivation

`remove-bimera-denovo` answers a binary question per sequence — is it a chimera of two more-abundant parents? — and discards the coverage that produced the answer. On long PacBio amplicons (this work used **nodA**, not 16S) and in low-biomass samples, some lower-abundance reads survive bimera removal yet look chimeric, consistent with being chimeras of **three or more** parents (trimeras). The bimera coverage signal is exactly what flags these: a read whose best single two-parent junction *nearly* spans its full length leaves a small internal gap a third parent can fill.

R DADA2 discards the same signal (`max_left`/`max_right` in `C_is_bimera` / `C_table_bimera2` are never returned), so there's no upstream facility for this.

## What this adds

A new **`chimera-diagnostics`** subcommand that reads a `make-sequence-table` or `remove-bimera-denovo` JSON and emits a per-sequence TSV of bimera *coverage* metrics. It does **not** filter or modify the table; the existing `is_bimera` / `table_bimera2` filter paths are untouched.

- `chimera.rs`: `BimeraDiagnostic` + `pooled_diagnostics` retain `max_left`/`max_right`, the end parents, the residual gap interval, a third-parent gap-mismatch test, plus the two disambiguating metrics below.
- `chimera_diagnostics.rs`: runs the pooled diagnostic over a `SequenceTable` and writes the TSV; `TrimeraCriteria` holds the suspect thresholds.
- CLI/main: `chimera-diagnostics` with `--trimera-{min-parent-dist,min-gap,max-gap-error,min-flank}`, `--align-backend`, threads, `-o`.

## Methodology note (why the screen looks the way it does)

The first cut keyed on coverage fraction and **over-called**: a few-SNP variant of one abundant parent is structurally identical to a trimera (non-bimera with an internal gap), and a small gap is trivially "filled" by almost any parent. Verified on real nodA data — e.g. one flagged ASV was 2 SNPs from a single parent, another 6 SNPs over 575 bp.

The refined `trimera_suspect` is gated on metrics the alignment pass already produces:
- **`nearest_parent_dist`** (min ends-free Hamming to any single parent) — the key variant-vs-mosaic disambiguator: a mosaic is close to *no* single parent.
- **third parent must beat the end parents in the gap** (`gap_mismatches < gap_end_parent_mismatches`).
- **both flanks `>= min_flank`** — a 3-segment mosaic needs two real junctions; rejects tiny-flank divergent singletons whose gap ≈ full length.
- **`min_gap_len`** — rejects the one-off-bimera tier (gap ≈ 1).

On a 5-sample nodA subset this cut suspects from 12+ → **1**: an abundant (2353) A-flanked / C-middle recombinant between the two dominant ASVs — the one genuine candidate. (Not yet ground-truthed against the known *Rhizobium* reference mixtures; that's the planned next step.)

## Tests

Synthetic trimera, plain-bimera, and SNP-variant-rejection unit tests; full suite + clippy green.

## Follow-up

Tracking issue to be linked — defaults are tuned on ~600 bp nodA and want validation against a reference-confirmed truth set; the `remove-bimera-denovo` refinement stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)