### PR TITLE
test(wfa): pin ends-free divergence (#102) + warn WFA concordance gates are fixture-scale

### DIFF
--- a/.github/workflows/concordance.yml
+++ b/.github/workflows/concordance.yml
@@ -82,6 +82,15 @@ jobs:
       # (learn-errors, dada, remove-bimera-denovo) runs with --align-backend
       # wfa2. WFA is ASV-equivalent to NW on this data, so it must clear the
       # same thresholds; this guards against the WFA path regressing.
+      #
+      # CAUTION — this gate is REASSURING BUT NOT SUFFICIENT. WFA's ends-free
+      # alignment is genuinely suboptimal (upstream WFA2-lib #102; see
+      # nwalign.rs::wfa_endsfree_known_divergence). On these small fixtures the
+      # divergence is below the count thresholds so the gate passes, but at
+      # scale WFA over-calls low-abundance ASVs (jaccard ~0.92-0.95 unbounded,
+      # ~0.997-0.999 capped) — see issue #51 scale validation. A green WFA gate
+      # means "did not regress on the fixture", NOT "WFA == NW". WFA stays
+      # EXPERIMENTAL; NW is the default + error-model backend.
       - name: Illumina (WFA) — run dada2-rs pipeline
         run: |
           ALIGN_BACKEND=wfa2 bash dev/concordance/run_illumina.sh \
@@ -95,6 +104,7 @@ jobs:
             echo "::notice::Illumina reference CSV not committed yet ($ref); skipping WFA comparison."
             exit 0
           fi
+          echo "::warning title=WFA gate is fixture-scale only::A green Illumina WFA gate means the experimental WFA backend did not regress on this small fixture, NOT that WFA == NW. WFA ends-free is suboptimal (WFA2-lib #102) and over-calls low-abundance ASVs at scale (issue #51). NW remains the default + error-model backend."
           python3 dev/concordance/compare_to_reference.py \
               --rs work/illumina_wfa/seqtab.nochim.json --reference "$ref" \
               --label illumina-wfa --min-abundance "$MIN_ABUNDANCE" \
@@ -149,6 +159,13 @@ jobs:
       # erases the slowdown (locally faster than NW) while staying ASV-identical
       # to the R reference (93=93). k=5 matches R's KMER_SIZE. WFA is
       # experimental; this gate guards the WFA+cap path against regressing.
+      #
+      # CAUTION — same caveat as the Illumina WFA gate: PASSING HERE IS
+      # FIXTURE-SCALE ONLY. The 93=93 match holds because the committed fixture
+      # is small; at 95-sample scale capped WFA is NW parity-to-slower (NOT the
+      # local speedup) and unbounded WFA is a 3.6x slowdown that over-calls ~160
+      # ASVs (issue #51 scale validation). The cap does not make WFA == NW — it
+      # bounds the divergence. Green = "did not regress on the fixture".
       - name: PacBio (WFA) — run + compare (if fixture present)
         run: |
           data=dev/concordance/data/pacbio
@@ -164,6 +181,7 @@ jobs:
             echo "::notice::PacBio reference CSV not committed yet ($ref); WFA pipeline ran, no comparison."
             exit 0
           fi
+          echo "::warning title=WFA gate is fixture-scale only::A green PacBio WFA gate means the experimental WFA+cap backend did not regress on this small fixture, NOT that WFA == NW. At scale capped WFA is NW parity-to-slower and unbounded WFA over-calls ~160 ASVs (issue #51). NW remains the default + error-model backend."
           python3 dev/concordance/compare_to_reference.py \
               --rs work/pacbio_wfa/seqtab.nochim.json --reference "$ref" \
               --label pacbio-k5-wfa --min-abundance "$MIN_ABUNDANCE" \

--- a/src/nwalign.rs
+++ b/src/nwalign.rs
@@ -1434,7 +1434,14 @@ pub fn raw_align_with_buf(
     // override (handy for sweeps). Replaces only the vectorized/ends-free path;
     // the gapless fast-path (above) and the homopolymer-aware path (below) are
     // left untouched. NOTE: WFA ends-free is not byte-identical to align_endsfree
-    // (see sweep_wfa_parity), though it is ASV-equivalent on tested data.
+    // (see sweep_wfa_parity / wfa_endsfree_known_divergence), though it is
+    // ASV-equivalent on tested data. Root cause is upstream WFA2-lib #102
+    // (suboptimal endsfree alignment when match score != 0): DADA2's match=+5
+    // means a free end-gap changes the number of scored columns, which WFA's
+    // cost-model pruning can't see, so it under-credits free end-gaps. The edit
+    // cap does NOT fix this (these are low-edit pairs that finish under budget);
+    // it only bounds the divergent-pair cost. Tracked for the fork's ends-free
+    // handling — see project_wfa_dependency_wfa2lib_rs.
     if (p.backend == AlignBackend::Wfa2 || *USE_WFA_BACKEND) && !use_homo {
         align_wfa_endsfree_with_buf(
             &raw1.seq,
@@ -2265,6 +2272,56 @@ mod tests {
                 shown += 1;
             }
         }
+    }
+
+    /// Deterministic characterization of the known WFA ends-free divergence
+    /// (upstream WFA2-lib #102: suboptimal endsfree alignment when match != 0).
+    ///
+    /// `s2` is exactly `s1` with the leading base dropped, so the optimal
+    /// ends-free alignment credits a FREE leading end-gap and scores every one
+    /// of the 51 shared columns as a match (51 * 5 = 255). WFA cannot see that
+    /// the free end-gap changes the scored-column count (its cost model treats
+    /// match as 0), so it instead places the gap one column in — a penalized
+    /// internal gap — and scores 255 - 8 = 247. This is NOT a tie-break or a
+    /// logic bug on our side: it is the upstream paradigm mismatch, and the edit
+    /// cap does NOT mask it (a 1-edit pair finishes far under any budget, so
+    /// there is no NW fallback). It is the mechanism behind WFA's low-abundance
+    /// ASV over-calls (jaccard ~0.999, not 1.000) seen at scale (issue #51).
+    ///
+    /// Asserted as a REGRESSION GUARD on the documented behavior: if a future
+    /// WFA/fork change makes WFA optimal here, this test will fail loudly and
+    /// should be updated to assert equality (i.e. the divergence is fixed).
+    #[test]
+    fn wfa_endsfree_known_divergence() {
+        // 52 nt; s2 = s1[1..] (leading base removed) — a single deletion.
+        let s1 = encode("AACAGCGCAAACCAACTCGCTAGCTAGCAAAATCTTGTGTTTCTGCCTAGCG");
+        let s2 = encode("ACAGCGCAAACCAACTCGCTAGCTAGCAAAATCTTGTGTTTCTGCCTAGCG");
+        assert_eq!(s2.len(), s1.len() - 1);
+
+        // align_endsfree finds the true optimum: free leading end-gap, every
+        // shared column a match.
+        let ef = align_endsfree(&s1, &s2, 5, -4, -8, -1);
+        let sef = score_alignment(&ef, 5, -4, -8);
+        assert_eq!(
+            sef, 255,
+            "align_endsfree should credit the free leading gap"
+        );
+
+        // WFA (uncapped) is strictly suboptimal here — the #102 symptom.
+        let mut buf = AlignBuffers::new();
+        align_wfa_endsfree_with_buf(&s1, &s2, 5, -4, -8, -1, i32::MAX, &mut buf);
+        let wfa = [buf.al0.clone(), buf.al1.clone()];
+        let swfa = score_alignment(&wfa, 5, -4, -8);
+        assert!(
+            swfa < sef,
+            "WFA ends-free is expected to be suboptimal here (#102); \
+             got wfa={swfa} vs endsfree={sef}. If WFA now matches, the upstream \
+             divergence may be fixed — update this guard to assert equality."
+        );
+        assert_eq!(
+            swfa, 247,
+            "documented WFA score: one penalized internal gap"
+        );
     }
 
     /// Randomized parity stress test: WFA must match `align_endsfree`'s optimal


### PR DESCRIPTION
## Summary

Two related changes hardening the **experimental WFA backend**'s test/CI story, following the issue #51 scale validation (full MiSeq SOP + PacBio 95-sample, both k, all three pool modes).

### 1. Deterministic regression guard for the known ends-free divergence
`nwalign.rs::wfa_endsfree_known_divergence` pins the upstream WFA2-lib **#102** suboptimality (suboptimal ends-free alignment when match score ≠ 0) with a concrete minimal counterexample: `s2 = s1` with the leading base dropped, so the true optimum credits a **free leading end-gap** (`align_endsfree` = 255) while WFA mis-places it as a penalized internal gap (247). Asserts the strict inequality so a future fork/upstream fix fails loudly and prompts updating the guard to assert equality. #102 is now cited in the `raw_align` doc comment, noting the edit cap does **not** mask this (low-edit pairs finish under budget — it's the mechanism behind the low-abundance ASV over-calls at scale).

### 2. Warn that the WFA concordance gates are fixture-scale only
The Illumina/PacBio WFA gates pass on the small committed fixtures, which is reassuring but **deceptive**: the divergence is below the count thresholds at fixture scale but at production scale WFA over-calls low-abundance ASVs (jaccard ~0.92–0.95 unbounded, parity-to-slower capped). Added a CAUTION comment block to each WFA gate plus a visible `::warning::` annotation in each compare step so the caveat surfaces in the CI run summary, not just in YAML comments.

A green WFA gate means **"did not regress on the fixture"**, NOT **"WFA == NW"**. NW remains the default + error-model backend; WFA stays experimental.

## Test plan
- `cargo test --release wfa_endsfree_known_divergence` passes (asserts 255 vs 247).
- Existing randomized `sweep_wfa_parity` / `wfa_diagnose` (ignored) unchanged.
- CI: concordance workflow unchanged in behavior; only adds warning annotations.

## Context
Closes the deferred test item under issue #51. Related: #49 (WFA dependency), #53 (edit-budget cap). BiWFA and the #102 pattern/text-swap trick were both evaluated and ruled out (swap fixes 8 / breaks 53 over 20k random pairs — doesn't generalize); the only real fix is a match-aware wavefront cost (fork), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)